### PR TITLE
Remove both functional and non-functional links to Tutorials page 

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -24,19 +24,19 @@
     <p>jQuery is a fast and concise JavaScript Library that simplifies HTML document traversing, event handling, animating, and Ajax interactions for rapid web development. <strong>jQuery is designed to change the way that you write JavaScript.</strong></p>
     <ul class="jq-checkpoints jq-clearfix">
       <li>
-        <a href="http://docs.jquery.com/Tutorials" title="Lightweight Footprint" class="jq-thickbox">Lightweight Footprint</a>
+        <a href="http://api.jquery.com" title="Lightweight Footprint" class="jq-thickbox">Lightweight Footprint</a>
         <div class="jq-checkpointSubhead">
           <p>About 31KB in size <em>(Minified and Gzipped)</em></p>
         </div>
       </li>
       <li>
-        <a href="http://docs.jquery.com/Tutorials" title="CSS3 Compliant" class="jq-thickbox">CSS3 Compliant</a>
+        <a href="http://api.jquery.com" title="CSS3 Compliant" class="jq-thickbox">CSS3 Compliant</a>
         <div class="jq-checkpointSubhead">
           <p>Supports CSS 1-3 selectors and more!</p>
         </div>
       </li>
       <li>
-        <a href="http://docs.jquery.com/Tutorials" title="Cross-browser" class="jq-thickbox">Cross-browser</a>
+        <a href="http://api.jquery.com" title="Cross-browser" class="jq-thickbox">Cross-browser</a>
         <div class="jq-checkpointSubhead">
           <p>IE 6.0+, FF 10+, Safari 5.0+, Opera, Chrome</p>
         </div>
@@ -121,7 +121,7 @@ return false;
         <pre>
           <code>$("p.neat").addClass("ohmy").show("slow");</code>
         </pre>
-        <a href="http://docs.jquery.com/Tutorials" class="jq-runCode">Run Code</a>
+        <a href="http://api.jquery.com" class="jq-runCode">Run Code</a>
         <p class="neat"><strong>Congratulations!</strong> You just ran a snippet of jQuery code. Wasn't that easy? There's lots of example code throughout the <strong><a href="http://docs.jquery.com/">documentation</a></strong> on this site. Be sure to give all the code a test run to see what happens.</p>
       </div>
     </div>
@@ -135,13 +135,10 @@ return false;
             <a href="http://docs.jquery.com/How_jQuery_Works">How jQuery Works</a>
           </li>
           <li>
-            <a href="http://docs.jquery.com/Tutorials">Tutorials</a>
+            <a href="http://api.jquery.com/">jQuery API Documentation</a>
           </li>
           <li>
             <a href="http://docs.jquery.com/Using_jQuery_with_Other_Libraries">Using jQuery with other libraries</a>
-          </li>
-          <li>
-            <a href="http://docs.jquery.com/">jQuery Documentation</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
This removes the links to the Tutorials page from the homepage content, but we need a separate commit to (I believe) web-base-template to get the links out of the header and footer navigation.
