### PR TITLE
Updating README.md to add last step

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ The `xmllint` and `xsltproc` utilities need to be in your path. If you are on Wi
 2. `cp config-sample.json config.json`
 3. Edit config.json per https://github.com/scottgonzalez/grunt-wordpress#config
 4. `grunt`
+5. `grunt wordpress-deploy`


### PR DESCRIPTION
Updated to add `grunt wordpress-deploy` as the last step since that wasn't obvious.
