### PR TITLE
Remove duplicate "does not"

### DIFF
--- a/pages/upgrade-guide/1.9.md
+++ b/pages/upgrade-guide/1.9.md
@@ -105,7 +105,7 @@ The `.data()` method had an undocumented and incredibly non-performant way to mo
 
 For many versions, nearly all jQuery methods that return new sets of nodes use the document order to sort the resulting set. (There are a few methods such as `.parents()`, which returns its results in reverse-document order, but those exceptions are already documented and have not changed in 1.9.)
 
-Before 1.9, sets that contained some connected and some disconnected nodes would be sorted inconsistently, depending on whether a disconnected node led the original unsorted set. As of 1.9, connected nodes are always placed at the beginning of the set in document order, and disconnected nodes are placed behind them. The jQuery Migrate plugin does not does _not_ restore the old behavior, which was somewhat random and unpredictable.
+Before 1.9, sets that contained some connected and some disconnected nodes would be sorted inconsistently, depending on whether a disconnected node led the original unsorted set. As of 1.9, connected nodes are always placed at the beginning of the set in document order, and disconnected nodes are placed behind them. The jQuery Migrate plugin does _not_ restore the old behavior, which was somewhat random and unpredictable.
 
 ### Loading and running scripts inside HTML content
 


### PR DESCRIPTION
It's a simple typo in the documentation.
