### PR TITLE
Supported browser versions are "(current - 1) or newer" only for rolling-release browsers.

### DIFF
--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -20,10 +20,10 @@
 		<tr>
 			<th>jQuery 1.x</th>
 			<td>6+</td>
-			<td rowspan="2">Current − 1 version</td>
-			<td rowspan="2">Current − 1 version</td>
-			<td rowspan="2">Current − 1 version</td>
-			<td rowspan="2">Current − 1 version</td>
+			<td rowspan="2">(current - 1) or newer</td>
+			<td rowspan="2">(current - 1) or newer</td>
+			<td rowspan="2">5.1+</td>
+			<td rowspan="2">12.1x, (current - 1) or newer</td>
 		</tr>
 		<tr>
 			<th>jQuery 2.x</th>
@@ -33,7 +33,8 @@
 </table>
 
 <p>Any problem with jQuery in the above browsers should be considered and reported as a bug in jQuery.</p>
-<p><em>Current - 1 version</em> denotes that we support the current stable version of the browser and the version that preceded it. For example, if the current version of a browser is 24.x, we support the 24.x and 23.x versions.</p>
+<p><em>(current - 1) or newer</em> denotes that we support the current stable version of the browser and the version that preceded it. For example, if the current version of a browser is 24.x, we support the 24.x and 23.x versions.</p>
+<p><em>12.1x, (current - 1) or newer</em> denotes that we support Opera 12.1x as well as last 2 versions of Opera. For example, if the current Opera version is 20.x, we support Opera 12.1x, 19.x and 20.x but not Opera 15.x through 18.x.</p>
 <hr>
 
 <h2>Unsupported Browsers</h2>


### PR DESCRIPTION
Also, added a note we support Opera 12.1x.

This is based on a recent discussion on the `jquery-devs-team` group.
