### PR TITLE
Download: Update the "jQuery Pre-Release Builds" section

### DIFF
--- a/pages/download.md
+++ b/pages/download.md
@@ -76,11 +76,11 @@ Be sure to test web pages that use jQuery in all the browsers you want to suppor
 
 ## jQuery Pre-Release Builds
 
-The jQuery team is constantly working to improve the code. Each commit to the Github repo generates a work-in-progress version of the code that we update on the jQuery CDN. _These versions are sometimes unstable and not suitable for production sites._ We recommend they be used to determine whether a bug has already been fixed when reporting bugs against released versions, or to see if new bugs have been introduced. There are two versions, one for the 1.x branch (supports IE 6/7/8) and one for the 2.x branch (not for use with old IE).
+The jQuery team is constantly working to improve the code. Each commit to the Github repo generates a work-in-progress version of the code that we update on the jQuery CDN. _These versions are sometimes unstable and not suitable for production sites._ We recommend they be used to determine whether a bug has already been fixed when reporting bugs against released versions, or to see if new bugs have been introduced. There are two versions, one for the `compat` branch (supports IE 8) and one for the `master` branch (not for use with old IE).
 
-<a href="http://code.jquery.com/jquery-git1.js" download>Download the work-in-progress jQuery **1.x** build</a>
+<a href="//code.jquery.com/jquery-compat-git.js" download>Download the work-in-progress jQuery Compat build</a>
 
-<a href="http://code.jquery.com/jquery-git2.js" download>Download the work-in-progress jQuery **2.x** build</a>
+<a href="//code.jquery.com/jquery-git.js" download>Download the work-in-progress jQuery build</a>
 
 ## Using jQuery with a CDN
 


### PR DESCRIPTION
We now have `compat` & `master` branches and we no longer support IE<8. Also,
links to the pre-release files have changed.

cc @dmethvin 