### PR TITLE
Index: Fix Sizzle link to always use http

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -74,7 +74,7 @@
 				<a href="//qunitjs.com" class="qunitjs small logo">QUnit</a>
 			</div>
 			<div class="project-tile six columns color sizzle-red">
-				<a href="//sizzlejs.com" class="sizzlejs small logo">Sizzle</a>
+				<a href="http://sizzlejs.com" class="sizzlejs small logo">Sizzle</a>
 			</div>
 		</section>
 	</section>


### PR DESCRIPTION
Sizzle does not have a certificate so when the link goes to https://sizzlejs.com it is broken.