### PR TITLE
Browser support: Update the site for jQuery 3.0.0

### DIFF
--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -9,35 +9,34 @@
 		<tr>
 			<th></th>
 			<th>Internet Explorer</th>
-			<th>Chrome</th>
-			<th>Firefox</th>
+			<th>Edge</th>
+			<th>Chrome, Firefox, Opera</th>
 			<th>Safari</th>
-			<th>Opera</th>
 			<th>iOS</th>
 			<th>Android</th>
 		</tr>
 	</thead>
 	<tbody>
 		<tr>
-			<th>jQuery 1.x</th>
-			<td>6+</td>
-			<td rowspan="2">(Current - 1) or Current</td>
-			<td rowspan="2">(Current - 1) or Current</td>
-			<td rowspan="2">5.1+</td>
-			<td rowspan="2">12.1x, (Current - 1) or Current</td>
+			<th>jQuery</th>
+			<td>9+</td>
+			<td rowspan="2">Current</td>
+			<td rowspan="2">(Current - 1) and Current</td>
+			<td rowspan="2">6.0+</td>
 			<td rowspan="2">6.1+</td>
 			<td rowspan="2">2.3, 4.0+</td>
 		</tr>
 		<tr>
-			<th>jQuery 2.x</th>
-			<td>9+</td>
+			<th>jQuery Compat</th>
+			<td>8+</td>
 		</tr>
 	</tbody>
 </table>
 
 <p>Any problem with jQuery in the above browsers should be reported as a bug in jQuery.</p>
-<p><em>(Current - 1) or Current</em> denotes that we support the current stable version of the browser and the version that preceded it. For example, if the current version of a browser is 24.x, we support the 24.x and 23.x versions.</p>
-<p><em>12.1x, (Current - 1) or Current</em> denotes that we support Opera 12.1x as well as last 2 versions of Opera. For example, if the current Opera version is 20.x, we support Opera 12.1x, 19.x and 20.x but not Opera 15.x through 18.x.</p>
+<p><em>(Current - 1) and Current</em> denotes that we support the current stable version of the browser and the version that preceded it. For example, if the current version of a browser is 24.x, we support the 24.x and 23.x versions.</p>
+<p><em>Current</em> denotes that we support only the latest stable build of the browser.</p>
+<p>If you need to support older browsers like Internet Explorer 6-7, Opera 12.17 or Safari 5.1, use <a href="https://code.jquery.com/jquery-1.11.3.min.js" download>jQuery 1.11.3</a>.</p>
 <hr>
 
 <h2>Unsupported Browsers</h2>


### PR DESCRIPTION
NOTE: don't merge it before we cut stable jQuery 3.0.0!

This PR is a preparation for the browser-support site changes that are needed for jQuery 3.0.0.

Apart from updating browsers' versions, I made a couple of changes:

1. I grouped Chrome, Firefox & Opera into one column; with the addition of Edge the table got *really* cramped and it may still get more entries if we decide to officially test on a Windows Phone.
2. I moved `jQuery` to be first & `jQuery Compat` to be second. At this point where we're starting discussing dropping IE8 in some not-so-absurdly-distant future, with additional platform support like Node (it wasn't really properly tested in 2.x) and, last but not least, considering that the name `jQuery` hints it is the main line it made sense to me to change the "default" version to choose.
3. Some people (hopefully not a lot) will still need to support mammoths like IE6 so I added a paragraph directing to the last version that supports them.
4. I changed `(Current - 1) or Current` to `(Current - 1) and Current` as we support both versions, not one of the other.

Edge is presented separately as we don't know if BrowserStack will make more than one build available. Edge will not have official version numbers but its user agent contains the build number in the form of `Edge/12.BUILD_NUMBER`; current build is 9600. If more than one build will be made available, I'd merge this column with the Chrome one.

Screenshots:

1. current page: ![screen shot 2015-06-29 at 19 20 34](https://cloud.githubusercontent.com/assets/1758366/8413864/f794117e-1e93-11e5-9ced-7ebaa7775d22.png)
2. page with this PR applied: ![screen shot 2015-06-29 at 19 28 55](https://cloud.githubusercontent.com/assets/1758366/8414009/1d97430e-1e95-11e5-8155-5912c53941a4.png)

cc @jquery/core

___

Things to consider:
* [ ] remove the "CSS contents and browser compatibility" link from "External References" at the bottom of the page; it was mostly relevant for IE<8 and most of the table has since been moved to another place.