### PR TITLE
Browser support: Test only on latest Opera

### DIFF
--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -9,8 +9,8 @@
 		<tr>
 			<th></th>
 			<th>Internet Explorer</th>
-			<th>Edge, Yandex.Browser</th>
-			<th>Chrome, Firefox, Opera</th>
+			<th>Edge, Opera, Yandex.Browser</th>
+			<th>Chrome, Firefox</th>
 			<th>Safari</th>
 			<th>iOS</th>
 			<th>Android</th>


### PR DESCRIPTION
Opera is now just another Chromium-based browser, like Yandex.Browser.
It doesn't make sense to test on two Opera versions.

cc @jquery/core as this needs to be officially decided by the team (this is just my proposal)