### PR TITLE
[Merged] Browser support: Remove Compat, add Android 2.3 note

### DIFF
--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -10,8 +10,7 @@
 			<th></th>
 			<th>Internet Explorer</th>
 			<th>Edge, Opera, Yandex.Browser</th>
-			<th>Chrome, Firefox</th>
-			<th>Safari</th>
+			<th>Chrome, Firefox, Safari</th>
 			<th>iOS</th>
 			<th>Android</th>
 		</tr>
@@ -22,8 +21,7 @@
 			<td>9+</td>
 			<td rowspan="2">Current</td>
 			<td rowspan="2">(Current - 1) and Current</td>
-			<td rowspan="2">7.0+</td>
-			<td rowspan="2">7.0+</td>
+			<td rowspan="2">7+</td>
 			<td rowspan="2">2.3, 4.0+</td>
 		</tr>
 		<tr>

--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -9,8 +9,8 @@
 		<tr>
 			<th></th>
 			<th>Internet Explorer</th>
-			<th>Edge, Yandex.Browser</th>
-			<th>Chrome, Firefox, Opera</th>
+			<th>Edge, Opera, Yandex.Browser</th>
+			<th>Chrome, Firefox</th>
 			<th>Safari</th>
 			<th>iOS</th>
 			<th>Android</th>

--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -4,37 +4,32 @@
 
 <h2>Current Active Support</h2>
 
-<table id="support-matrix">
-	<thead>
-		<tr>
-			<th></th>
-			<th>Internet Explorer</th>
-			<th>Edge, Opera, Yandex.Browser</th>
-			<th>Chrome, Firefox, Safari</th>
-			<th>iOS</th>
-			<th>Android</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<th>jQuery</th>
-			<td>9+</td>
-			<td rowspan="2">Current</td>
-			<td rowspan="2">(Current - 1) and Current</td>
-			<td rowspan="2">7+</td>
-			<td rowspan="2">2.3, 4.0+</td>
-		</tr>
-		<tr>
-			<th>jQuery Compat</th>
-			<td>8+</td>
-		</tr>
-	</tbody>
-</table>
+<h3>Desktop</h3>
+<ul>
+	<li>Chrome: (Current - 1) and Current</li>
+	<li>Edge: Current</li>
+	<li>Firefox: (Current - 1) and Current</li>
+	<li>Internet Explorer: 9+</li>
+	<li>Safari: (Current - 1) and Current</li>
+	<li>Opera: Current</li>
+	<li>Yandex.Browser: Current</li>
+</ul>
+
+<h3>Mobile</h3>
+<ul>
+	<li>Android: 4.0+ (plus limited 2.3 support)</li>
+	<li>iOS: 7+</li>
+</ul>
 
 <p>Any problem with jQuery in the above browsers should be reported as a bug in jQuery.</p>
+
 <p><em>(Current - 1) and Current</em> denotes that we support the current stable version of the browser and the version that preceded it. For example, if the current version of a browser is 24.x, we support the 24.x and 23.x versions.</p>
+
 <p><em>Current</em> denotes that we support only the latest stable build of the browser.</p>
-<p>If you need to support older browsers like Internet Explorer 6-7, Opera 12.17 or Safari 5.1-6.0, use <a href="https://code.jquery.com/jquery-1.11.3.min.js" download>jQuery 1.11.3</a>.</p>
+
+<p>Android 2.3 is supported in a very limited way: jQuery shouldn't crash on it and basic methods should work; edge cases &amp; various bugs are not worked around.</p>
+
+<p>If you need to support older browsers like Internet Explorer 6-8, Opera 12.16-12.17 or Safari 5.1+, use <a href="https://code.jquery.com/jquery-1.11.3.min.js" download>jQuery 1.11.3</a>.</p>
 <hr>
 
 <h2>Unsupported Browsers</h2>

--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -22,8 +22,8 @@
 			<td>9+</td>
 			<td rowspan="2">Current</td>
 			<td rowspan="2">(Current - 1) and Current</td>
-			<td rowspan="2">6.0+</td>
-			<td rowspan="2">6.1+</td>
+			<td rowspan="2">7.0+</td>
+			<td rowspan="2">7.0+</td>
 			<td rowspan="2">2.3, 4.0+</td>
 		</tr>
 		<tr>
@@ -36,7 +36,7 @@
 <p>Any problem with jQuery in the above browsers should be reported as a bug in jQuery.</p>
 <p><em>(Current - 1) and Current</em> denotes that we support the current stable version of the browser and the version that preceded it. For example, if the current version of a browser is 24.x, we support the 24.x and 23.x versions.</p>
 <p><em>Current</em> denotes that we support only the latest stable build of the browser.</p>
-<p>If you need to support older browsers like Internet Explorer 6-7, Opera 12.17 or Safari 5.1, use <a href="https://code.jquery.com/jquery-1.11.3.min.js" download>jQuery 1.11.3</a>.</p>
+<p>If you need to support older browsers like Internet Explorer 6-7, Opera 12.17 or Safari 5.1-6.0, use <a href="https://code.jquery.com/jquery-1.11.3.min.js" download>jQuery 1.11.3</a>.</p>
 <hr>
 
 <h2>Unsupported Browsers</h2>

--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -9,7 +9,7 @@
 		<tr>
 			<th></th>
 			<th>Internet Explorer</th>
-			<th>Edge</th>
+			<th>Edge, Yandex.Browser</th>
 			<th>Chrome, Firefox, Opera</th>
 			<th>Safari</th>
 			<th>iOS</th>

--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -9,35 +9,34 @@
 		<tr>
 			<th></th>
 			<th>Internet Explorer</th>
-			<th>Chrome</th>
-			<th>Firefox</th>
+			<th>Edge</th>
+			<th>Chrome, Firefox, Opera</th>
 			<th>Safari</th>
-			<th>Opera</th>
 			<th>iOS</th>
 			<th>Android</th>
 		</tr>
 	</thead>
 	<tbody>
 		<tr>
-			<th>jQuery 1.x</th>
-			<td>6+</td>
-			<td rowspan="2">(Current - 1) or Current</td>
-			<td rowspan="2">(Current - 1) or Current</td>
-			<td rowspan="2">5.1+</td>
-			<td rowspan="2">12.1x, (Current - 1) or Current</td>
+			<th>jQuery</th>
+			<td>9+</td>
+			<td rowspan="2">Current</td>
+			<td rowspan="2">(Current - 1) and Current</td>
+			<td rowspan="2">6.0+</td>
 			<td rowspan="2">6.1+</td>
 			<td rowspan="2">2.3, 4.0+</td>
 		</tr>
 		<tr>
-			<th>jQuery 2.x</th>
-			<td>9+</td>
+			<th>jQuery Compat</th>
+			<td>8+</td>
 		</tr>
 	</tbody>
 </table>
 
 <p>Any problem with jQuery in the above browsers should be reported as a bug in jQuery.</p>
-<p><em>(Current - 1) or Current</em> denotes that we support the current stable version of the browser and the version that preceded it. For example, if the current version of a browser is 24.x, we support the 24.x and 23.x versions.</p>
-<p><em>12.1x, (Current - 1) or Current</em> denotes that we support Opera 12.1x as well as last 2 versions of Opera. For example, if the current Opera version is 20.x, we support Opera 12.1x, 19.x and 20.x but not Opera 15.x through 18.x.</p>
+<p><em>(Current - 1) and Current</em> denotes that we support the current stable version of the browser and the version that preceded it. For example, if the current version of a browser is 24.x, we support the 24.x and 23.x versions.</p>
+<p><em>Current</em> denotes that we support only the latest stable build of the browser.</p>
+<p>If you need to support older browsers like Internet Explorer 6-7, Opera 12.17 or Safari 5.1, use <a href="https://code.jquery.com/jquery-1.11.3.min.js" download>jQuery 1.11.3</a>.</p>
 <hr>
 
 <h2>Unsupported Browsers</h2>

--- a/pages/index.html
+++ b/pages/index.html
@@ -36,7 +36,7 @@
 		<div class="feature-box cross-browser four columns center-txt">
 			<div class="feature-box-image"></div>
 			<h3>Cross-Browser</h3>
-			<p><a href="/browser-support/">IE, Firefox, Safari, Opera, Chrome, and more</a></p>
+			<p><a href="/browser-support/">Chrome, Edge, Firefox, IE, Safari, Android, iOS, and more</a></p>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
jQuery Compat is no longer planned; the table was changed to a regular list.

Also, a note that Android 2.3 is supported in a very limited way was added.

Before:
![screen shot 2015-10-26 at 22 38 18](https://cloud.githubusercontent.com/assets/1758366/10743477/a6eb6724-7c33-11e5-8093-fd5ecc75d1e7.png)

After:
![screen shot 2015-10-26 at 23 38 40](https://cloud.githubusercontent.com/assets/1758366/10744507/ba44fb26-7c3a-11e5-9467-24265c22b82e.png)

Thoughts, @jquery/core?

EDIT: The "After" version updated.