### PR TITLE
Download: Add subresource integrity to CDN examples

### DIFF
--- a/pages/download.md
+++ b/pages/download.md
@@ -91,11 +91,17 @@ if the visitor to your webpage has already downloaded a copy of jQuery from the 
 
 To use the jQuery CDN, just reference the file directly from `http://code.jquery.com` in the script tag:
 ```
-<script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
-<script src="//code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+<script src="https://code.jquery.com/jquery-1.11.3.min.js"
+        integrity="sha384-+54fLHoW8AHu3nHtUxs9fW2XKOZ2ZwKHB5olRtKSDTKJIb1Na1EceFZMS8E72mzW"
+        crossorigin="anonymous"></script>
+<script src="//code.jquery.com/jquery-migrate-1.2.1.min.js"
+        integrity="sha384-9tt8DlZQhE63eBuKml9tnMclfDeo/8/wstzUrBQStZZkCCvwfw78IiV+r9o600g2"
+        crossorigin="anonymous"></script>
 ```
 
 Starting with jQuery 1.9, [sourcemap files](http://blog.jquery.com/2013/01/09/jquery-1-9-rc1-and-migrate-rc1-released/#sourcemaps) are available on the jQuery CDN as well. If compressed files are included directly from the CDN as shown above, sourcemap-aware browsers such as Google Chrome will use them when you enable sourcemap support.
+
+In the interest of security, the jQuery Foundation CDN supports [https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity](Subresource Integrity) which allows the browser to verify that the files being delivered have not been modified. This [http://www.w3.org/TR/SRI/](specification) is currently being implimented by browsers and including the new integrity attribute will ensure your application gains this security increase as browsers support it.
 
 To see all available files and versions, visit [http://code.jquery.com](http://code.jquery.com)
 


### PR DESCRIPTION
We also need to add the hashes for people to use to code.jquery.com which is being tracked in https://github.com/jquery/codeorigin.jquery.com/issues/20 and should add this where ever it makes sense on other project sites referring to using the CDN