### PR TITLE
Download: Add a "Downloading jQuery using npm" section

### DIFF
--- a/pages/download.md
+++ b/pages/download.md
@@ -49,8 +49,15 @@ Please read the [2.0 release notes](http://blog.jquery.com/2013/04/18/jquery-2-0
 [jQuery 2.2.1 release
 notes](http://blog.jquery.com/2016/02/22/jquery-1-12-1-and-2-2-1-released/)
 
+## Downloading jQuery using npm
+jQuery is registered as [a package](https://www.npmjs.com/package/jquery) on [npm](https://www.npmjs.com/). You can install the latest version of jQuery with the command:
+```
+npm install jquery
+```
+This will install jQuery in the `node_modules` directory. Within `node_modules/jquery/dist/` you will find an uncompressed release, a compressed release, and a map file.
+
 ## Downloading jQuery using Bower
-jQuery is registered as a package with [Bower](http://bower.io). You can install the latest version of jQuery with the command:
+jQuery is also registered as a package with [Bower](http://bower.io). You can install the latest version of jQuery with the command:
 ```
 bower install jquery
 ```


### PR DESCRIPTION
Fixes #122 

Screenshot: <img width="969" alt="screen shot 2016-03-09 at 11 56 51" src="https://cloud.githubusercontent.com/assets/1758366/13633231/101af0a6-e5ee-11e5-8d4e-09ed5f975631.png">

The Bower section looks really similar now; perhaps we should simplify it now that it's not a recommended way to get jQuery? We could change it to a simple mention and redirect people to Bower docs for more info (e.g. target directory). Thoughts?