### PR TITLE
Docs: Document Deferred rejection callback return value handling

### DIFF
--- a/pages/upgrade-guide/3.0.md
+++ b/pages/upgrade-guide/3.0.md
@@ -274,38 +274,18 @@ https://github.com/jquery/jquery/issues/1751
 
 Deferreds have been updated for compatibility with Promises/A+ and ES2015 (a.k.a ES6) Promise, a change with significant consequences.
 
+https://github.com/jquery/jquery/issues/1722  
+https://github.com/jquery/jquery/issues/2102  
+
 ##### Resolution
 
 `.resolve`, `.reject`, and `.notify` now set `undefined` context instead of using the promise of the Deferred object with which they are associated. To set an explicit context, use `.resolveWith`, `.rejectWith`, and `.notifyWith`.
 
 https://github.com/jquery/jquery/issues/3060
 
-##### Callbacks
+##### Callback exit
 
-Major changes have been made to the `.then()` method. In particular, any exception thrown within a `.then()` callback now becomes a rejection value and we *strongly recommend* that you add a `.catch()` method (new in 3.0) to the end of your promise chain to avoid difficult debugging issues. The most likely place you may encounter this new behavior is when using the Deferreds that are produced by `jQuery.ajax()`, since the `jQXHR` object returned is a superset of `jQuery.Deferred`.
-
-The Promises/A+ spec says that promises are always resolved with a <em>single value</em> and handlers are invoked without a `this` context, while `jQuery.ajax()` sometimes passes context and/or multiple values to its handlers. In most cases, though, the first argument is the most important of these values. If you are currently using a `.then()` you may only receive a single argument in your handler. To get context and/or more arguments, switch to the older `.done()` and `.fail()` methods which retain all the backward-compatible behavior:
-
-```js
-// Typical old uses of .then() that are not Promises/A+ compatible
-$.ajax("url").then(
-    // success
-    function( data, textStatus, jqXHR ) { /* code */ },
-    // error
-    function( jqXHR, textStatus, errorThrown ) { /* code */ }
-);
-
-// Rewrite to this in order to maintain previous behavior
-$.ajax("url")
-    // success
-    .done(function( data, textStatus, jqXHR ) { /* code */ })
-    // error
-    .fail(function( jqXHR, textStatus, errorThrown ) { /* code */ });
-```
-
-Another behavior change required for Promises/A+ compliance is that Deferred `.then()` callbacks are *always* called asynchronously. Previously, if a `.then()` callback was added to a Deferred that was already resolved or rejected, the callback would run immediately and synchronously.
-
-Deferred methods such as `.done()`, `.fail()`, and `.pipe()` retain their old behavior and so are not Promises/A+ compliant. If you require synchronous resolution, do not want exceptions converted to rejection values, or want thrown errors to bubble out of the function where they occur, you can use these methods instead of `.then()` and `.catch()`.
+Major changes have been made to the `.then()` method. In particular, any exception thrown within a `.then()` callback is now caught and converted into a rejection value, and any non-thenable value returned from a _rejection_ handler becomes a fulfillment value. We **strongly recommend** that you add a `.catch()` method (new in 3.0) to the end of your promise chain to avoid difficult debugging issues. The most likely place you may encounter this new behavior is when using the Deferreds that are produced by `jQuery.ajax()`, since the `jQXHR` object returned is a superset of `jQuery.Deferred`.
 
 In jQuery 1.x and 2.x, an uncaught exception inside a callback function halts code execution. The thrown exception bubbles up until it is caught inside a try/catch or reaches `window` and triggers `window.onerror`.
 
@@ -340,9 +320,34 @@ $.ajax("/status")
 
 Note that jQuery logs a message to the console when it is inside a Deferred and a JavaScript exception occurs. These messages take the form `jQuery.Deferred exception: (error message)`. If you do not want any console output on these exceptions, set `jQuery.Deferred.exceptionHook` to `undefined`. If you need further help in finding errors reported this way, use the [jquery-deferred-reporter plugin](https://github.com/dmethvin/jquery-deferred-reporter) during development to obtain stack traces.
 
-https://github.com/jquery/jquery/issues/1722  
-https://github.com/jquery/jquery/issues/2102  
 https://github.com/jquery/jquery/issues/2736  
+
+##### Callback invocation
+
+The Promises/A+ spec says that promises are always resolved with a <em>single value</em> and handlers are invoked without a `this` context, while jQuery Deferreds sometimes pass context and/or multiple values to their handlers. In most cases, though, the first argument is the most important of these values. If you are currently using `.then()`, you may only receive a single argument in your handler. To get context and/or more arguments, switch to the older `.done()` and `.fail()` methods which retain all the backward-compatible behavior:
+
+```js
+// Typical old uses of .then() that are not Promises/A+ compatible
+$.ajax("url").then(
+    // success
+    function( data, textStatus, jqXHR ) { /* code */ },
+    // error
+    function( jqXHR, textStatus, errorThrown ) { /* code */ }
+);
+
+// Rewrite to this in order to maintain previous behavior
+$.ajax("url")
+    // success
+    .done(function( data, textStatus, jqXHR ) { /* code */ })
+    // error
+    .fail(function( jqXHR, textStatus, errorThrown ) { /* code */ });
+```
+
+Another behavior change required for Promises/A+ compliance is that Deferred `.then()` callbacks are *always* called asynchronously. Previously, if a `.then()` callback was added to a Deferred that was already resolved or rejected, the callback would run immediately and synchronously.
+
+##### Backwards compatibility
+
+Deferred methods such as `.done()`, `.fail()`, and `.pipe()` retain their old behavior and so are not Promises/A+ compliant. If you require synchronous resolution, do not want exceptions converted to rejection values or rejection callback returns converted to fulfillment values, or want thrown errors to bubble out of the function where they occur, you can use these methods instead of `.then()` and `.catch()`.
 
 #### Breaking change and Feature: jQuery.when() inputs and progress notifications
 


### PR DESCRIPTION
I forgot all about rejection handlers returning _fulfillment_ values until seeing it mentioned in the draft 3.0 RC announcement.