### PR TITLE
Browser support: Clarify support on mobile devices

### DIFF
--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -16,8 +16,8 @@
 
 <h3>Mobile</h3>
 <ul>
-	<li>Android: 4.0+</li>
-	<li>iOS: 7+</li>
+	<li>Stock browser on Android 4.0+</li>
+	<li>Safari on iOS 7+</li>
 </ul>
 
 <p>Any problem with jQuery in the above browsers should be reported as a bug in jQuery.</p>


### PR DESCRIPTION
This a request to clarify the Mobile section in the Browser support page with the changes discussed in [issue 136](/jquery/jquery.com/issues/136).