### PR TITLE
Remove External References section from the Browser Support page [Closes 104]

### DIFF
--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -44,10 +44,3 @@
 <h2>About CSS Selector Compatibility</h2>
 <p>Regardless of a browser's support of CSS selectors, all selectors listed at <a href="https://api.jquery.com/category/selectors/">api.jquery.com/category/selectors/</a> will return the correct set of elements when passed as an argument of the <code>jQuery</code> function.</p>
 <p>CSS styles applied with jQuery's <code>.css()</code> method are dependent on the browser's level of support. In general, jQuery does not attempt to overcome the limitations of a browser's style rendering. (One exception is <code>opacity</code>, which jQuery "shims" for older Internet Explorer's alternative implementation.) Furthermore, prior to version 1.8, jQuery does not normalize vendor-prefixed properties.</p>
-
-<h3>External References</h3>
-<ul>
-	<li><a href="http://www.quirksmode.org/css/contents.html">CSS contents and browser compatibility</a></li>
-	<li><a href="https://en.wikipedia.org/wiki/Comparison_of_layout_engines_%28Cascading_Style_Sheets%29">Comparison of layout engines (Cascading Style Sheets)</a></li>
-	<li><a href="https://en.wikipedia.org/wiki/Acid3">Acid3</a></li>
-</ul>


### PR DESCRIPTION
Removes the **External Resources** section from the **Browser Support** page (```http://jquery.com/browser-support/```) as per #104.

cc: @mgol  