### PR TITLE
remove link to try.jquery.com from resources

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -80,7 +80,6 @@
 			<li><a href="https://contribute.jquery.com">Contribute to jQuery</a></li>
 			<li><a href="https://jquery.org">About the jQuery Foundation</a></li>
 			<li><a href="https://github.com/jquery/jquery/issues">Browse or Submit jQuery Bugs</a></li>
-			<li class="try-jquery"><a href="http://try.jquery.com">Try jQuery</a></li>
 		</ul>
 
 	</aside>


### PR DESCRIPTION
On June 1, 2018, Code School will be shutting down and the existing Try jQuery course is not being migrated to Pluralsight.  I'm on the Code School/Pluralsight team.  This PR removes the link to Try jQuery from jquery.com.