### PR TITLE
Please add new CDN: PageCDN

### DIFF
--- a/pages/download.md
+++ b/pages/download.md
@@ -108,6 +108,7 @@ The following CDNs also host compressed and uncompressed versions of jQuery rele
 
 * [Google CDN](https://developers.google.com/speed/libraries/devguide#jquery)
 * [Microsoft CDN](https://www.asp.net/ajax/cdn#jQuery_Releases_on_the_CDN_0)
+* [PageCDN](https://pagecdn.com/lib/jquery)
 * [CDNJS CDN](https://cdnjs.com/libraries/jquery/)
 * [jsDelivr CDN](https://www.jsdelivr.com/package/npm/jquery)
 


### PR DESCRIPTION
PageCDN uses brotli-11 compression that reduces jquery.min.js size by another few KBs compared to other CDNs.
It would be a NICE addition to your downloads page.
Thanks.