### PR TITLE
Remove duplicate "may"

### DIFF
--- a/pages/upgrade-guide/3.0.md
+++ b/pages/upgrade-guide/3.0.md
@@ -372,7 +372,7 @@ https://github.com/jquery/jquery/issues/2710
 ### Dimensions
 #### Breaking change: .width(), .height(), .css("width"), and .css("height") can return non-integer values
 
-Before version 3.0, jQuery used the DOM `offsetWidth` and `offsetHeight` properties to determine the dimensions of an element, and these properties always return integers. With jQuery 3.0 we get more precise values via the DOM `getBoundingClientRect` API, and these may may not be integers. If your code always expects integers for dimensions, it may need to be adjusted to deal with this extra precision.
+Before version 3.0, jQuery used the DOM `offsetWidth` and `offsetHeight` properties to determine the dimensions of an element, and these properties always return integers. With jQuery 3.0 we get more precise values via the DOM `getBoundingClientRect` API, and these may not be integers. If your code always expects integers for dimensions, it may need to be adjusted to deal with this extra precision.
 
 https://github.com/jquery/jquery/issues/1724
 


### PR DESCRIPTION
Fixed a small error in the upgrade guide.
It said "... and these **may may** not be integers...".
