### PR TITLE
Browser support: Update Android Browser support status

### DIFF
--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -16,9 +16,11 @@
 
 <h3>Mobile</h3>
 <ul>
-	<li>Stock browser on Android 4.0+</li>
+	<li>Stock browser on Android 4.0+<sup>[1]</sup></li>
 	<li>Safari on iOS 7+</li>
 </ul>
+
+<p>[1] Workarounds for Android Browser 4.0-4.3 are present in the code base but we no longer actively test these versions.</p>
 
 <p>Any problem with jQuery in the above browsers should be reported as a bug in jQuery.</p>
 

--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -20,7 +20,7 @@
 	<li>Safari on iOS 7+</li>
 </ul>
 
-<p>[1] Workarounds for Android Browser 4.0-4.3 are present in the code base but we no longer actively test these versions.</p>
+<p>[1] Workarounds for Android Browser 4.0-4.3 are present in the code base, but we no longer actively test these versions.</p>
 
 <p>Any problem with jQuery in the above browsers should be reported as a bug in jQuery.</p>
 


### PR DESCRIPTION
Workarounds for Android Browser 4.0-4.3 are present in the code base but
we no longer actively test these versions.