### PR TITLE
Upgrade guide: Use the new Migrate API to enable the self-closed-tags patch

### DIFF
--- a/pages/upgrade-guide/3.5.md
+++ b/pages/upgrade-guide/3.5.md
@@ -6,12 +6,12 @@
 
 ### A workaround
 
-If you want to upgrade to jQuery 3.5.0 or newer and don't have time to deal with breaking changes at the moment and you use jQuery Migrate 3.2.0 or newer, you can revert to the previous behavior by invoking:
+If you want to upgrade to jQuery 3.5.0 or newer and don't have time to deal with breaking changes at the moment, and you use jQuery Migrate 3.4.0 or newer, you can revert to the previous behavior by invoking:
 ```js
-jQuery.UNSAFE_restoreLegacyHtmlPrefilter();
+jQuery.migrateEnablePatches( "self-closed-tags" );
 ```
 
-jQuery Migrate 3.3.0 or newer logs warnings for all input that's affected by this change, regardless of whether the `jQuery.UNSAFE_restoreLegacyHtmlPrefilter()` method was called or not. **Note**: if you overwrite `jQuery.htmlPrefilter` manually, you'll lose those warnings!
+jQuery Migrate 3.3.0 or newer logs warnings for all input that's affected by this change, regardless of whether the `jQuery.migrateEnablePatches( "self-closed-tags" )` method was called or not. **Note**: if you overwrite `jQuery.htmlPrefilter` manually, you'll lose those warnings!
 
 If you don't use jQuery Migrate, don't add it just for this one workaround. Instead, you can revert to the previous behavior by redefining `jQuery.htmlPrefilter` after loading jQuery:
 ```js
@@ -21,7 +21,7 @@ jQuery.htmlPrefilter = function( html ) {
 };
 ```
 
-Note that if you do this, you lose the jQuery 3.5.0 security fix and you have to be more careful with what HTML you pass to jQuery manipulation methods; regular HTML sanitizing will not be enough. Some security libraries have special sanitization settings for jQuery. For example, [DOMPurify](https://github.com/cure53/DOMPurify) has a `SAFE_FOR_JQUERY` flag:
+Note that if you do this, you lose the jQuery 3.5.0 security fix, and you have to be more careful with what HTML you pass to jQuery manipulation methods; regular HTML sanitizing will not be enough. Some security libraries have special sanitization settings for jQuery. For example, [DOMPurify](https://github.com/cure53/DOMPurify) has a `SAFE_FOR_JQUERY` flag:
 ```js
 var sanitizedHtml = DOMPurify.sanitize( unsafeHtml, { SAFE_FOR_JQUERY: true } );
 elem.html( sanitizedHtml );
@@ -49,7 +49,7 @@ In jQuery 3.5.0, the `jQuery.htmlPrefilter` method always returns its argument u
 
 To avoid this, don't use self-closing tags for tags that may have content unless your page runs in XHTML mode. Make sure you're sending a correct mime type: `application/xhtml+xml`; otherwise, your page will really run in HTML mode. 
 
-If you're writing a library and you want it to work both in HTML & XHTML modes, remember to use self-closing tags for empty elements, i.e. ones that don't have closing tags in HTML. For example, instead of:
+If you're writing a library, and you want it to work both in HTML & XHTML modes, remember to use self-closing tags for empty elements, i.e. ones that don't have closing tags in HTML. For example, instead of:
 ```js
 jQuery( "<div/><img/>" );
 ```
@@ -62,4 +62,4 @@ One popular input that still works in jQuery 3.5.0 or newer is the one with a si
 ```js
 jQuery( "<div class='yellow' />" );
 ```
-This is becuse it's XHTML-compliant and in HTML the parser first changes it to just the opening tag: `<div class='yellow'>` but then immediately auto-closes it as it reaches the end of input.
+This is because it's XHTML-compliant and in HTML the parser first changes it to just the opening tag: `<div class='yellow'>` but then immediately auto-closes it as it reaches the end of input.

--- a/pages/upgrade-guide/3.5.md
+++ b/pages/upgrade-guide/3.5.md
@@ -11,7 +11,7 @@ If you want to upgrade to jQuery 3.5.0 or newer and don't have time to deal with
 jQuery.migrateEnablePatches( "self-closed-tags" );
 ```
 
-jQuery Migrate 3.3.0 or newer logs warnings for all input that's affected by this change, regardless of whether the `jQuery.migrateEnablePatches( "self-closed-tags" )` method was called or not. **Note**: if you overwrite `jQuery.htmlPrefilter` manually, you'll lose those warnings!
+As long as this method has been called, jQuery Migrate 3.4.0 or newer logs warnings for all input that's affected by this change. **Note**: if you overwrite `jQuery.htmlPrefilter` manually, you'll lose those warnings!
 
 If you don't use jQuery Migrate, don't add it just for this one workaround. Instead, you can revert to the previous behavior by redefining `jQuery.htmlPrefilter` after loading jQuery:
 ```js
@@ -21,7 +21,7 @@ jQuery.htmlPrefilter = function( html ) {
 };
 ```
 
-Note that if you do this, you lose the jQuery 3.5.0 security fix, and you have to be more careful with what HTML you pass to jQuery manipulation methods; regular HTML sanitizing will not be enough. Some security libraries have special sanitization settings for jQuery. For example, [DOMPurify](https://github.com/cure53/DOMPurify) has a `SAFE_FOR_JQUERY` flag:
+Note that if you do this, you lose the jQuery 3.5.0 security fix, and you have to be more careful with what HTML you pass to jQuery manipulation methods; regular HTML sanitizing will not be enough. Some security libraries have special sanitization settings for jQuery. For example, [DOMPurify](https://github.com/cure53/DOMPurify/tree/2.0.17#can-i-configure-dompurify) used to support the `SAFE_FOR_JQUERY` flag in versions `2.0.17` or older:
 ```js
 var sanitizedHtml = DOMPurify.sanitize( unsafeHtml, { SAFE_FOR_JQUERY: true } );
 elem.html( sanitizedHtml );


### PR DESCRIPTION
Advise to use the new API:
```js
jQuery.migrateEnablePatches( "self-closed-tags" );
```
instead of the deprecated one:
```js
jQuery.UNSAFE_restoreLegacyHtmlPrefilter();
```

Also, fix some grammar mistakes & typos.