### PR TITLE
Browser support: Indicate iOS 7 is no longer tested

### DIFF
--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -17,10 +17,10 @@
 <h3>Mobile</h3>
 <ul>
 	<li>Stock browser on Android 4.0+<sup>[1]</sup></li>
-	<li>Safari on iOS 7+</li>
+	<li>Safari on iOS 7+<sup>[1]</sup></li>
 </ul>
 
-<p>[1] Workarounds for Android Browser 4.0-4.3 are present in the code base, but we no longer actively test these versions.</p>
+<p>[1] Workarounds for Android Browser 4.0-4.3 & iOS 7 are present in the code base, but we no longer actively test these versions. iOS 8 & newer versions are tested.</p>
 
 <p>Any problem with jQuery in the above browsers should be reported as a bug in jQuery.</p>
 


### PR DESCRIPTION
We had to drop iOS 7 testing as iOS simulators are no longer supported
by BrowserStack and there are no real devices for iOS <10. We continue
to rely on old iOS emulators for testing as long as they work. iOS 8.3 & 9.3
seem to work fine for now but iOS 7.0 was breaking a lot; right now, the
browser doesn't even start.

Before:
<img width="834" alt="Screen Shot 2022-06-27 at 22 09 17" src="https://user-images.githubusercontent.com/1758366/176027311-0ede645c-4698-431e-824a-171384be3ed9.png">

After:
<img width="962" alt="Screen Shot 2022-06-27 at 22 09 04" src="https://user-images.githubusercontent.com/1758366/176027337-b4905322-6920-4b09-8be2-aba173fff599.png">
