### PR TITLE
Browser support:Download: Drop mentions of oldversion.com

### DIFF
--- a/pages/browser-support.html
+++ b/pages/browser-support.html
@@ -39,7 +39,7 @@
 <hr>
 
 <h2>About Browser Support</h2>
-<p>jQuery is constantly tested with all of its supported browsers via unit tests. However, a web page using jQuery may not work in the same set of browsers if its own code takes advantage of (or falls prey to) browser-specific behaviors. Testing is essential to fully support a browser. The Microsoft Edge Developer site makes available <a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">virtual machines</a> for testing many different versions of Internet Explorer. Older versions of other browsers can be found at <a href="http://oldversion.com/">oldversion.com</a>.</p>
+<p>jQuery is constantly tested with all of its supported browsers via unit tests. However, a web page using jQuery may not work in the same set of browsers if its own code takes advantage of (or falls prey to) browser-specific behaviors. Testing is essential to fully support a browser. The Microsoft Edge Developer site makes available <a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">virtual machines</a> for testing many versions of Internet Explorer.
 
 <p>Only the most current version of jQuery is tested and updated to fix bugs or add features. Users of older versions that find a bug should upgrade to the latest released version to determine if the bug has already been fixed. The <a href="https://github.com/jquery/jquery-migrate/#readme">jQuery Migrate plugin</a> may be helpful in identifying and fixing problems during a version upgrade.</p>
 

--- a/pages/download.md
+++ b/pages/download.md
@@ -77,7 +77,7 @@ The second version helps you update code to run on jQuery 3.0 or higher, *once y
 
 ## Cross-Browser Testing with jQuery
 
-Be sure to test web pages that use jQuery in all the browsers you want to support. The [Microsoft Developer Resources](https://developer.microsoft.com/en-us/microsoft-edge/) site makes available [virtual machines](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/) for testing many different versions of Internet Explorer. Older versions of other browsers can be found at [oldversion.com](http://oldversion.com/).
+Be sure to test web pages that use jQuery in all the browsers you want to support. The [Microsoft Developer Resources](https://developer.microsoft.com/en-us/microsoft-edge/) site makes available [virtual machines](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/) for testing many versions of Internet Explorer.
 
 ## jQuery Pre-Release Builds
 


### PR DESCRIPTION
It's not secure to install browsers from a third-party site that's only
available via insecure HTTP. Besides, with most browsers updating quickly
nowadays, there are not that many reasons to test on very old versions of most
browsers.

Therefore, let's just remove oldversion.com mentions without a replacement.

Ref gh-212