### PR TITLE
Support: New page

### DIFF
--- a/pages/support.md
+++ b/pages/support.md
@@ -1,0 +1,74 @@
+<script>
+{
+	"title": "jQuery Support"
+}
+</script>
+
+## Community support
+
+The following learning resources are available online and free of charge:
+
+* [jQuery Learning Center](https://learn.jquery.com/)
+* [jQuery API Documentation](https://api.jquery.com/)
+* [jQuery UI Demos](https://jqueryui.com/demos/)
+* [jQuery UI API Documentation](https://api.jqueryui.com/)
+
+### Matrix chat
+
+jQuery is on Matrix! The support channel for jQuery is [#jquery_jquery:gitter.im](https://app.element.io/#/room/#jquery_jquery:gitter.im). You can [read the channel on Element](https://app.element.io/#/room/#jquery_jquery:gitter.im) without an account, or [join the channel](https://matrix.to/#/#jquery_jquery:gitter.im) via any Matrix client.
+
+We use the public [#jquery_dev channel](https://app.element.io/#/room/#jquery_dev:gitter.im) to discuss project developments. We also hold [weekly meetings](https://meetings.jquery.org/) on Matrix.
+
+### IRC chat
+
+We are on [Libera Chat IRC](https://libera.chat/) in the `#jquery` channel where you can ask for support. You can [join via webchat](https://web.libera.chat/#jquery), or via any IRC client.
+
+### StackOverflow
+
+StackOverflow is a great place to ask questions and find support for all jQuery projects. Search or create [questions tagged with "jquery"](https://stackoverflow.com/questions/tagged/jquery), or refer to the ["jquery" tag introduction](https://stackoverflow.com/tags/jquery/info).
+
+### Archives
+
+* [Freenode IRC chat channels](https://irc.jquery.org/) (2011-2021)
+* [jQuery Forum](https://forum.jquery.com/) (2010-2021): For questions and advice regarding jQuery Core, jQuery UI, Themeroller, QUnit, development of jQuery Plugins, and more.
+* [jQuery Accessibility mailing list](https://groups.google.com/group/jquery-a11y) (2008-2016).
+
+## Commercial support
+
+The following companies offer commercial support services for jQuery.
+
+* **[Bocoup](https://bocoup.com/)** builds complex cross device and cross platform JavaScript software for startups, the Fortune 500, and federally funded education projects. Bocoup offers in-depth JavaScript training on a number of subjects including jQuery. Learn more at <https://bocoup.com/services/training> or contact at <https://bocoup.com/contact>.
+
+-------
+
+## Follow us
+
+jQuery on Mastodon and the Fediverse:
+
+* [@jquery@social.lfx.dev](https://social.lfx.dev/@jquery)
+* [@qunit@fosstodon.org](https://fosstodon.org/@qunit)
+* [@openjsf@social.lfx.dev](https://social.lfx.dev/@openjsf)
+
+jQuery on Twitter:
+
+* [@jquery](https://twitter.com/jquery)
+* [@jqueryui](https://twitter.com/jqueryui)
+* [@jquerymobile](https://twitter.com/jquerymobile)
+* [@qunitjs](https://twitter.com/qunitjs)
+* [@jqcon](https://twitter.com/jqcon)
+
+-------
+
+## Media & Press inquiry
+
+Journalists seeking information on jQuery should contact: [info@jquery.com](mailto:info@jquery.com).
+
+For guidance on branding and trademark usage, visit <https://brand.jquery.org/>.
+
+-------
+
+## Found a bug?
+
+For reporting bugs in libraries, documentation, or content, the project's GitHub issues tracker should be used. All jQuery projects can be found at https://github.com/jquery
+
+Still haven't found what you're looking for? Please feel free to contact: [info@jquery.com](mailto:info@jquery.com)


### PR DESCRIPTION
Inspired by these existing pages:

* https://jquery.org/support/ Imported from https://github.com/jquery/jquery.org/tree/d6d5143291598324d7888c70c9db482dd3046336/pages
* https://jqueryui.com/support/ Imported from https://github.com/jquery/jqueryui.com/pull/204
* https://learn.jquery.com/contributing/#getting-help
* https://brand.jquery.org/press-contact/ Recently changed in https://github.com/jquery/brand.jquery.org/pull/25
* https://irc.jquery.org/#current-channels
* https://meetings.jquery.org/#join

@timmywil If you like this, I would propose that we redirect `jquery.org/support/` here (https://github.com/jquery/jquery.org/issues/139). The others could either also redirect or perhaps be condensed in favour of a reference to this page. What do you think?