### PR TITLE
Index: restore "Resources" block style, remove JQF/Other projects

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -52,36 +52,16 @@
 		a multitude of browsers. With a combination of versatility and
 		extensibility, jQuery has changed the way that millions of people write
 		JavaScript.</p>
-
-		<h2 class="block">Other Related Projects</h2>
-		<section class="project-tiles row">
-			<a href="https://jqueryui.com" class="project-tile six columns color secondary-orange">
-				<div class="jqueryui small logo">jQueryUI</div>
-			</a>
-			<a href="https://jquerymobile.com" class="project-tile six columns color secondary-green">
-				<div class="jquery-mobile small logo">jQuery Mobile</div>
-			</a>
-		</section>
-		<section class="project-tiles row">
-			<a href="https://qunitjs.com" class="project-tile six columns color qunit-secondary-purple">
-				<div class="qunitjs small logo">QUnit</div>
-			</a>
-			<a href="https://sizzlejs.com" class="project-tile six columns color sizzle-red">
-				<div class="sizzlejs small logo">Sizzle</div>
-			</a>
-		</section>
 	</section>
-	<aside class="four columns resources">
-		<h3>Resources</h3>
+	<aside class="four columns">
+		<h2 class="block">Resources</h2>
 		<ul>
 			<li><a href="https://api.jquery.com">jQuery Core API Documentation</a></li>
 			<li><a href="https://learn.jquery.com">jQuery Learning Center</a></li>
 			<li><a href="https://blog.jquery.com">jQuery Blog</a></li>
 			<li><a href="https://contribute.jquery.com">Contribute to jQuery</a></li>
-			<li><a href="https://jquery.org">About the jQuery Foundation</a></li>
 			<li><a href="https://github.com/jquery/jquery/issues">Browse or Submit jQuery Bugs</a></li>
 		</ul>
-
 	</aside>
 </div>
 
@@ -118,4 +98,14 @@
 		}
 	});
 	</pre></code>
+</section>
+
+<section>
+	<h2 class="block">Related Projects</h2>
+
+	<h3><a href="https://jqueryui.com/">jQuery UI</a></h3>
+	<p>This project is in maintenance-only mode. <a href="https://blog.jquery.com/2021/10/07/jquery-maintainers-update-and-transition-jquery-ui-as-part-of-overall-modernization-efforts/">Learn more</a>.</p>
+
+	<h3><a href="https://jquerymobile.com/">jQuery Mobile</a></h3>
+	<p>This project is deprecated. <a href="https://blog.jqueryui.com/2021/10/jquery-maintainers-continue-modernization-initiative-with-deprecation-of-jquery-mobile/">Learn more</a>.</p>
 </section>


### PR DESCRIPTION
The "Resources" section felt a bit lost on the home page due to the large padding and lack of block styling on its heading. It used to have a custom styling via `id="sidebar"` which was similar to a block, but was lost at some point without replacement. https://web.archive.org/web/20130301123913/jquery.com

Change it to a proper `<h2 class="block">` to look more on par with the rest of the page, and also remove the `padding-left: 60px` from the .resources class which is redundant now.

Also:
* remove outdated "About the jQuery Foundation" link.

* remove "Other Related Projects" section, which used low-quality images, was broken on mobile, loaded an extra copy of these logos on the home page, gave high-prominence to deprecated jQuery Mobile, and maintenance-only jQuery UI, used an outdated version of the QUnit logo.

  Perhaps the global navigation which points to the same projects already, suffices?

  By removing these, we bring the first code example above the fold, which seems valuable. If we keep it, I'd suggest moving it to the bottom of the content section at least.

| Before | After
|--|--
| <img width="857" alt="Screenshot" src="https://github.com/jquery/jquery.com/assets/156867/a3afb661-fbad-42ad-a3ee-0d96a1feeaf2"> | <img width="857" alt="Screenshot" src="https://github.com/jquery/jquery.com/assets/156867/ce945c3f-ec46-4868-9d5c-4fbeed562b41">
| <img width="1552" alt="Screenshot" src="https://github.com/jquery/jquery.com/assets/156867/7d69b8b7-437a-43b3-a5c2-ac84403e60de"> | <img width="1552" alt="Screenshot" src="https://github.com/jquery/jquery.com/assets/156867/c3790e6a-70bd-472b-80a1-0e2e5ccdb8fa">

