### PR TITLE
Download: enable h1, reduce decisions, remove old info

### DIFF
--- a/pages/download.md
+++ b/pages/download.md
@@ -1,106 +1,86 @@
 <script>{
-	"title": "Download jQuery",
-	"customFields": [
-		{ "key": "hide_title", "value": 1 }
-	]
+	"title": "Download jQuery"
 }</script>
 
-## Downloading jQuery
-
-Compressed and uncompressed copies of jQuery files are available. The uncompressed file is best used during development or debugging; the compressed file saves bandwidth and improves performance in production.
-You can also download a [sourcemap file](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) for use when debugging with a compressed file.
-The map file is _not_ required for users to run jQuery, it just improves the developer's debugger experience.
-As of jQuery 1.11.0/2.1.0 the `//# sourceMappingURL` comment is [not included](https://blog.jquery.com/2014/01/24/jquery-1-11-and-2-1-released/) in the compressed file.
+## Latest version
 
 To locally download these files, right-click the link and select "Save as..." from the menu.
 
-### jQuery
+Download the compressed, production version:
 
-For help when upgrading jQuery, please see the [upgrade guide](/upgrade-guide/) most relevant to your version.
-We also recommend using the [jQuery Migrate plugin](https://github.com/jquery/jquery-migrate).
+<a class="button db" href="https://code.jquery.com/jquery-3.7.1.min.js">Download jQuery 3.7.1</a>
 
-<a href="https://code.jquery.com/jquery-3.7.1.min.js" download>Download the compressed, production jQuery 3.7.1</a>
+* [Download the uncompressed development version of jQuery 3.7.1](https://code.jquery.com/jquery-3.7.1.js)
+* [Download the map file for jQuery 3.7.1](https://code.jquery.com/jquery-3.7.1.min.map)
+* [jQuery 3.7.1 blog post with release notes](https://blog.jquery.com/2023/08/28/jquery-3-7-1-released-reliable-table-row-dimensions/)
 
-<a href="https://code.jquery.com/jquery-3.7.1.js" download>Download the uncompressed, development jQuery 3.7.1</a>
+The slim build is a smaller version, that excludes the [ajax](https://api.jquery.com/category/ajax/) and [effects](https://api.jquery.com/category/effects/) modules:
 
-<a href="https://code.jquery.com/jquery-3.7.1.min.map" download>Download the map file for jQuery 3.7.1</a>
+* [Download jQuery 3.7.1 slim build](https://code.jquery.com/jquery-3.7.1.slim.min.js)
+* [Download the uncompressed development version of the jQuery 3.7.1 slim build](https://code.jquery.com/jquery-3.7.1.slim.js)
+* [Download the map for the jQuery 3.7.1 slim build](https://code.jquery.com/jquery-3.7.1.slim.min.map)
 
-You can also use the slim build, which excludes the [ajax](https://api.jquery.com/category/ajax/) and [effects](https://api.jquery.com/category/effects/) modules:
+The uncompressed version is best used during development or debugging; the compressed file saves bandwidth and improves performance in production. You can download the [source map](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) file to help with debugging the compressed production version. The source map is _not_ required for end-users to run jQuery, it just improves the developer's debugging experience. As of jQuery 1.11/2.1, we [no longer link source maps](https://blog.jquery.com/2014/01/24/jquery-1-11-and-2-1-released/) to compressed releases by default.
 
-<a href="https://code.jquery.com/jquery-3.7.1.slim.min.js" download>Download the compressed, production jQuery 3.7.1 slim build</a>
+Browse the jQuery CDN at **[releases.jquery.com](https://releases.jquery.com)** for a full list of assets, including older and historical versions.
 
-<a href="https://code.jquery.com/jquery-3.7.1.slim.js" download>Download the uncompressed, development jQuery 3.7.1 slim build</a>
+### Upgrade
 
-<a href="https://code.jquery.com/jquery-3.7.1.slim.min.map" download>Download the map file for the jQuery 3.7.1 slim build</a>
+For help when upgrading jQuery, read the [upgrade guide](/upgrade-guide/).
+We also recommend using the [jQuery Migrate plugin](https://github.com/jquery/jquery-migrate)
 
-[jQuery 3.7.1 blog post with release notes](https://blog.jquery.com/2023/08/28/jquery-3-7-1-released-reliable-table-row-dimensions/)
+### jQuery Migrate Plugin
+
+The [jQuery Migrate plugin](https://github.com/jquery/jquery-migrate/#readme) simplifies upgrading from older versions of jQuery. The plugin restores deprecated features and behaviors so that older code will still run properly on newer versions of jQuery.
+
+When upgrading from a pre-1.9 jQuery version to jQuery 1.9 or upto jQuery 3.0, first use jQuery Migrate 1.x:
+
+* <a href="https://code.jquery.com/jquery-migrate-1.4.1.min.js">Download jQuery Migrate 1.4.1</a> (compressed production version)
+* <a href="https://code.jquery.com/jquery-migrate-1.4.1.js">Download the uncompressed, development jQuery Migrate 1.4.1</a>
+
+When migrating from jQuery 3.x to a later jQuery 3.x version, use jQuery Migrate 3.x instead:
+
+* <a href="https://code.jquery.com/jquery-migrate-3.4.0.min.js">Download jQuery Migrate 3.4.0</a> (compressed production version)
+* <a href="https://code.jquery.com/jquery-migrate-3.4.0.js">Download the uncompressed, development jQuery Migrate 3.4.0</a>
+
+Use the _compressed production_ version to simply restore compatibility issues without changing any application code.
+
+Use the _uncompressed development_ version to additionally diagnose and help migrate compatibility issues, through helpful warnings on the console that identify how to transition your application code.
 
 ## Downloading jQuery using npm or Yarn
-jQuery is registered as [a package](https://www.npmjs.com/package/jquery) on [npm](https://www.npmjs.com/). You can install the latest version of jQuery with the npm CLI command:
+jQuery is published on [npm](https://www.npmjs.com/) under the [jquery package](https://www.npmjs.com/package/jquery). You can install the latest version of jQuery with the npm CLI:
 ```
 npm install jquery
 ```
-As an alternative you can use the [Yarn](https://github.com/yarnpkg/yarn) CLI command:
+As an alternative you can use the [Yarn CLI](https://github.com/yarnpkg/yarn):
 ```
 yarn add jquery
 ```
 This will install jQuery in the `node_modules` directory. Within `node_modules/jquery/dist/` you will find an uncompressed release, a compressed release, and a map file.
 
-## Downloading jQuery using Bower
-jQuery is also registered as a package with [Bower](https://bower.io). You can install the latest version of jQuery with the command:
-```
-bower install jquery
-```
-This will install jQuery to Bower's install directory, the default being `bower_components`. Within `bower_components/jquery/dist/` you will find an uncompressed release, a compressed release, and a map file.
-
-The jQuery Bower package contains additional files besides the default distribution. In most cases you can ignore these files, however if you wish to download the default release on its own you can use Bower to install jQuery from one of the above urls instead of the registered package. For example, if you wish to install just the compressed jQuery file, you can install just that file with the following command:
-```
-bower install https://code.jquery.com/jquery-3.7.1.min.js
-```
-
-## jQuery Migrate Plugin
-
-We have created the [jQuery Migrate plugin](https://github.com/jquery/jquery-migrate/#readme)
-to simplify the transition from older versions of jQuery. The plugin restores deprecated features and behaviors so that older code will still run properly on newer versions of jQuery. Use the _uncompressed development_ version to diagnose compatibility issues, it will generate warnings on the console that you can use to identify and fix problems. Use the _compressed production_ version to simply fix compatibility issues without generating console warnings.
-
-There are two versions of Migrate. The first will help you update your pre-1.9 jQuery code to jQuery 1.9 up to 3.0. You can get that version here:
-
-<a href="https://code.jquery.com/jquery-migrate-1.4.1.min.js" download>Download the compressed, production jQuery Migrate 1.4.1</a>
-
-<a href="https://code.jquery.com/jquery-migrate-1.4.1.js" download>Download the uncompressed, development jQuery Migrate 1.4.1</a>
-
-The second version helps you update code to run on jQuery 3.0 or higher, *once you have used Migrate 1.x and upgraded to jQuery 1.9 or higher*:
-
-<a href="https://code.jquery.com/jquery-migrate-3.4.0.min.js" download>Download the compressed, production jQuery Migrate 3.4.0</a>
-
-<a href="https://code.jquery.com/jquery-migrate-3.4.0.js" download>Download the uncompressed, development jQuery Migrate 3.4.0</a>
-
 ## jQuery Pre-Release Builds
 
-The jQuery team is constantly working to improve the code. Each commit to the Github repo generates a work-in-progress version of the code that we update on the jQuery CDN. _These versions are sometimes unstable and never suitable for production sites._ We recommend they be used to determine whether a bug has already been fixed when reporting bugs against released versions, or to see if new bugs have been introduced.
+The jQuery team is constantly working to improve the code. Each commit to the Github repo generates a work-in-progress version of the code that we update on the jQuery CDN. We recommend they be used to determine whether a bug has already been fixed when reporting bugs against released versions, or to see if new bugs have been introduced.
 
-<a href="https://releases.jquery.com/git/jquery-git.js" download>Download the work-in-progress jQuery build</a>
+_These versions are sometimes unstable and never suitable for production sites._
 
-## Using jQuery with a CDN
+<a href="https://releases.jquery.com/jquery/">Browse Git builds of jQuery</a>
 
-[CDNs](https://en.wikipedia.org/wiki/Content_delivery_network) can offer a performance benefit by hosting jQuery on servers spread across the globe. This also offers an advantage that
-if the visitor to your webpage has already downloaded a copy of jQuery from the same CDN, it won't have to be re-downloaded.
-
-### jQuery's CDN provided by [StackPath](https://www.stackpath.com)
-
-The jQuery CDN supports [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) which allows the browser to verify that the files being delivered have not been modified. This [specification](https://www.w3.org/TR/SRI/) is currently being implemented by browsers. Adding the new integrity attribute will ensure your application gains this security improvement as browsers support it.
+## [jQuery CDN](https://releases.jquery.com)
 
 To use the jQuery CDN, just reference the file in the script tag directly from the jQuery CDN domain. You can get the complete script tag, including Subresource Integrity attribute, by visiting https://releases.jquery.com and clicking on the version of the file that you want to use. Copy and paste that tag into your HTML file.
 
+The jQuery CDN supports [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) ([specification](https://www.w3.org/TR/SRI/)) which allows the browser to verify that the files being delivered have not been modified. Adding the new integrity attribute will ensure your application gains this security improvement in supporting browsers.
+
 Starting with jQuery 1.9, [sourcemap files](https://blog.jquery.com/2013/01/09/jquery-1-9-rc1-and-migrate-rc1-released/#sourcemaps) are available on the jQuery CDN. However, as of version 1.10.0/2.1.0 the compressed jQuery no longer includes the sourcemap comment in CDN copies because it requires the uncompressed file and sourcemap file to be placed at the same location as the compressed file. If you are maintaining local copies and can control the locations all three files, you can add the sourcemap comment to the compressed file for easier debugging.
 
-To see all available files and versions, visit [https://releases.jquery.com](https://releases.jquery.com)
+To see all available files and versions, including older and historical versions, visit [https://releases.jquery.com](https://releases.jquery.com)
 
 ### Other CDNs
 
 The following CDNs also host compressed and uncompressed versions of jQuery releases. Starting with jQuery 1.9 they may also host [sourcemap files](https://blog.jquery.com/2013/01/09/jquery-1-9-rc1-and-migrate-rc1-released/#sourcemaps); check the site's documentation.
 
-**Note that there may be delays between a jQuery release and its availability there. Please be patient, they receive the files at the same time the blog post is made public. Beta and release candidates are not hosted by these CDNs.**
+Note that **there may be delays between a jQuery release and its availability there**. Please be patient, they receive the files at the same time the blog post is made public. Beta and release candidates are not hosted by these CDNs.
 
 * [Google CDN](https://developers.google.com/speed/libraries#jquery)
 * [Microsoft CDN](https://learn.microsoft.com/en-us/aspnet/ajax/cdn/overview#jQuery_Releases_on_the_CDN_0)
@@ -109,34 +89,13 @@ The following CDNs also host compressed and uncompressed versions of jQuery rele
 
 ## About the Code
 
-**jQuery is provided under the <a href="https://jquery.org/license/">MIT license</a>.**
+**jQuery is provided under the <a href="https://jquery.com/license/">MIT license</a>.**
 
-The code is hosted and developed in the [jQuery GitHub repository](https://github.com/jquery/jquery). If you've spotted some areas of code that could be improved, please feel free to discuss it on the [Developing jQuery Core Forum](https://forum.jquery.com/developing-jquery-core). If you'd like to participate in developing jQuery, peruse our [contributor site](https://contribute.jquery.org) for more information.
+The code is hosted and developed in the [jQuery GitHub repository](https://github.com/jquery/jquery). If you've spotted some areas of code that could be improved, feel free to [report a bug](https://forum.jquery.com/developing-jquery-core). If you'd like to participate in developing jQuery, peruse our [contributor site](https://contribute.jquery.org) for more information.
 
-To find and download plugins developed by jQuery contributors, please visit the <a href="https://plugins.jquery.com/">Plugins site</a>. Plugin authors are responsible for maintenance of their plugins. Feedback on plugins should be directed to the plugin author, not the jQuery team.
+Feedback about a jQuery plugin should be directed to the plugin author, not the jQuery team.
 
-### Build from Git
-
-*Note:* To just use the latest work-in-progress version of jQuery, please try the jQuery Pre-Release Build described above.
-
-All source code is kept under Git revision control, which you can browse online. The repository's <a href="https://github.com/jquery/jquery/blob/master/README.md">README</a> has more information on building and testing your own jQuery, as well as instructions on creating a custom build that excludes some APIs to reduce file size.
-
-If you have access to Git, you can connect to the repository here:
-
-``` bash
-git clone git://github.com/jquery/jquery.git
-```
-
-You can also check out and build a specific version of jQuery from GitHub:
-
-``` bash
-git clone git://github.com/jquery/jquery.git
-git checkout 1.2.6
-```
-
-The README file for a specific version will have instructions for building that version, as the process has changed over time.
-
-***
+-----
 
 ## Past Releases
 

--- a/pages/download.md
+++ b/pages/download.md
@@ -20,7 +20,7 @@ The slim build is a smaller version, that excludes the [ajax](https://api.jquery
 * [Download the uncompressed development version of the jQuery 3.7.1 slim build](https://code.jquery.com/jquery-3.7.1.slim.js)
 * [Download the map for the jQuery 3.7.1 slim build](https://code.jquery.com/jquery-3.7.1.slim.min.map)
 
-The uncompressed version is best used during development or debugging; the compressed file saves bandwidth and improves performance in production. You can download the [source map](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) file to help with debugging the compressed production version. The source map is _not_ required for end-users to run jQuery, it just improves the developer's debugging experience. As of jQuery 1.11/2.1, we [no longer link source maps](https://blog.jquery.com/2014/01/24/jquery-1-11-and-2-1-released/) to compressed releases by default.
+The uncompressed version is best used during development or debugging; the compressed file saves bandwidth and improves performance in production. You can download the [source map](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) file to help with debugging the compressed production version. The source map is _not_ required for end-users to run jQuery; it is a tool to help improve a developer's debugging experience. As of jQuery 1.11/2.1, we [no longer link source maps](https://blog.jquery.com/2014/01/24/jquery-1-11-and-2-1-released/) to compressed releases by default.
 
 Browse the jQuery CDN at **[releases.jquery.com](https://releases.jquery.com)** for a full list of assets, including older and historical versions.
 
@@ -68,7 +68,7 @@ _These versions are sometimes unstable and never suitable for production sites._
 
 ## [jQuery CDN](https://releases.jquery.com)
 
-To use the jQuery CDN, just reference the file in the script tag directly from the jQuery CDN domain. You can get the complete script tag, including Subresource Integrity attribute, by visiting https://releases.jquery.com and clicking on the version of the file that you want to use. Copy and paste that tag into your HTML file.
+To use the jQuery CDN, reference the file in the script tag directly from the jQuery CDN domain. You can get the complete script tag, including Subresource Integrity attribute, by visiting https://releases.jquery.com and clicking on the version of the file that you want to use. Copy and paste that tag into your HTML file.
 
 The jQuery CDN supports [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) ([specification](https://www.w3.org/TR/SRI/)) which allows the browser to verify that the files being delivered have not been modified. Adding the new integrity attribute will ensure your application gains this security improvement in supporting browsers.
 
@@ -91,7 +91,7 @@ Note that **there may be delays between a jQuery release and its availability th
 
 **jQuery is provided under the <a href="https://jquery.com/license/">MIT license</a>.**
 
-The code is hosted and developed in the [jQuery GitHub repository](https://github.com/jquery/jquery). If you've spotted some areas of code that could be improved, feel free to [report a bug](https://forum.jquery.com/developing-jquery-core). If you'd like to participate in developing jQuery, peruse our [contributor site](https://contribute.jquery.org) for more information.
+The code is hosted and developed in the [jQuery GitHub repository](https://github.com/jquery/jquery). If you've spotted some areas of code that could be improved, feel free to [report a bug](https://contribute.jquery.org/bug-reports/). If you'd like to participate in developing jQuery, peruse our [contributor site](https://contribute.jquery.org) for more information.
 
 Feedback about a jQuery plugin should be directed to the plugin author, not the jQuery team.
 


### PR DESCRIPTION
* Enable the h1 heading. The page content has no custom h1 of its own so looks out of place with other pages on jquery.com.

* Invert the order of some paragraphs so that links are clear and at the top, with a single recommended option each time and then other links in a bullet list after it.

  E.g. there is now an actual "Download jQuery 3.7.1" button, describing over top that it is the compressed production version, and then a list of other links.

  Explanations of these files now follow the list instead of being in front of it, thus burying the links less.

* Promote link to browse releases.jquery.com to the first section.

  I've personally never used the links that were in the first section previously as they always felt like too much text to read. When I land on the releases list, I know what each variant is and feel more confident that I'm getting the right one instead of reading the long link labels. If we like this direction and shorter links, taking into account that many people probably already "start" at releases.jquery.com based on links to there from other places and thus only see the short versions there, we could also explore shortening the labels here. I've not done that in this commit yet.

* Remove outdated info about source maps still being a future/emerging technology.

* Remove instructions for Bower.

* Move up "jQuery Migrate plugin" section to the top, right after to "Upgrade".

* Improve "Yarn" CLI link readability by giving it the full term as its link label, "Yarn CLI" instead of only partly linked.

* Improve "npm" sentence by linking "npm" and then naming "jquery package" in the second link.

* Update Pre-Release section to link to releases site instead of to a single file, since there are now quite a lot of variants of this file that people may want to choose between.

* Update "jQuery CDN" section heading to link to the releases site from its name, and remove outdated sponsorship mention.

* Improve "Other CDNs" by applying the bolding more focussedly (when an entire paragraph is bold, it's the same as bolding nothing, is my rule of thumb). Ensure the bolded portion is readable and understandable by itself.

* Remove "Build from Git" section, covered by README where it is presumably more up to date. This is linked to from "About the code".

* Remove mention of closed jQuery Forum from "About the code", instead link to "Report a bug", matching the link chosen at https://github.com/jquery/jquery-wp-content/issues/220.

* Remove mention of plugins.jquery.com from "About the code". Ref https://github.com/jquery/infrastructure-puppet/issues/29.