### PR TITLE
Upgrade guide: Don't use deprecated AJAX event aliases

### DIFF
--- a/pages/upgrade-guide/1.9.md
+++ b/pages/upgrade-guide/1.9.md
@@ -27,7 +27,7 @@ For more information see the [jQuery Migrate plugin](https://github.com/jquery/j
 
 The list below does not represent all changes made for jQuery 1.9, just the changes that we anticipate may affect behavior in a way that could break existing code. For a complete and detailed list of changes, see the changelogs in the release announcements on the [jQuery blog](https://blog.jquery.com) or visit [bugs.jquery.com](https://bugs.jquery.com).
 
-### .toggle(function, function, ... ) removed
+### .toggle( function, function, ... ) removed
 
 This is the "click an element to run the specified functions" signature of `.toggle()`. It should not be confused with the "change the visibility of an element" of `.toggle()` which is not deprecated. The former is being removed to reduce confusion and improve the potential for modularity in the library. The jQuery Migrate plugin can be used to restore the functionality.
 
@@ -37,11 +37,11 @@ The `jQuery.browser()` method has been deprecated since jQuery 1.3 and is remove
 
 ### .live() removed
 
-The `.live()` method has been deprecated since jQuery 1.7 and has been removed in 1.9. We recommend upgrading code to use the `.on()` method instead. To exactly match `$("a.foo").live("click", fn)`, for example, you can write `$(document).on("click", "a.foo", fn)`. For more information, see the [.on() documentation](https://api.jquery.com/on/). In the meantime, the jQuery Migrate plugin can be used to restore the `.live()` functionality.
+The `.live()` method has been deprecated since jQuery 1.7 and has been removed in 1.9. We recommend upgrading code to use the `.on()` method instead. To exactly match `$( "a.foo" ).live( "click", fn )`, for example, you can write `$( document ).on( "click", "a.foo", fn )`. For more information, see the [`.on()` documentation](https://api.jquery.com/on/). In the meantime, the jQuery Migrate plugin can be used to restore the `.live()` functionality.
 
 ### .die() removed
 
-The `.die()` method has been deprecated since jQuery 1.7 and has been removed in 1.9. We recommend upgrading code to use the `.off()` method instead. To exactly match `$("a.foo").die("click")`, for example, you can write `$(document).off("click", "a.foo")`. For more information, see the [.off() documentation](https://api.jquery.com/off/). In the meantime, the jQuery Migrate plugin can be used to restore the `.die()` functionality.
+The `.die()` method has been deprecated since jQuery 1.7 and has been removed in 1.9. We recommend upgrading code to use the `.off()` method instead. To exactly match `$( "a.foo" ).die( "click" )`, for example, you can write `$( document ).off( "click", "a.foo" )`. For more information, see the [`.off()` documentation](https://api.jquery.com/off/). In the meantime, the jQuery Migrate plugin can be used to restore the `.die()` functionality.
 
 ### jQuery.sub() removed
 
@@ -53,7 +53,7 @@ The `.add()` method is always supposed to return its results in document order. 
 
 ### .addBack( selector ) replaces .andSelf()
 
-As of jQuery 1.8, the `.andSelf()` method was deprecated in favor of the `.addBack()` method, which we feel is a better name for what this method does--"add back" the previous set of results. The new method accepts an optional selector that can be used to filter the previous set before adding it to the current set. So, `$("section, aside").children("ul").addBack("aside")` results in a set that includes all `aside` nodes plus the `ul` children of both `section` and `aside` nodes, in document order. Although the `.andSelf()` method still works in 1.9, we recommend switching names as soon as possible. The jQuery Migrate plugin will warn about the use of `.andSelf()`.
+As of jQuery 1.8, the `.andSelf()` method was deprecated in favor of the `.addBack()` method, which we feel is a better name for what this method does--"add back" the previous set of results. The new method accepts an optional selector that can be used to filter the previous set before adding it to the current set. So, `$( "section, aside" ).children( "ul" ).addBack( "aside" )` results in a set that includes all `aside` nodes plus the `ul` children of both `section` and `aside` nodes, in document order. Although the `.andSelf()` method still works in 1.9, we recommend switching names as soon as possible. The jQuery Migrate plugin will warn about the use of `.andSelf()`.
 
 ### .after(), .before(), and .replaceWith() with disconnected nodes
 
@@ -61,36 +61,40 @@ Prior to 1.9, `.after()`, `.before()`, and `.replaceWith()` would attempt to add
 
 ### .appendTo, .insertBefore, .insertAfter, and .replaceAll
 
-As of 1.9, these methods _always_ return a new set, making them consistently usable with chaining and the `.end()` method. Prior to 1.9, they would return the old set only if there was a single target element. Note that these methods have always returned the aggregate set of all elements appended to the target elements. If no elements are selected by the target selector (e.g., `$(elements).appendTo("#not_found")`) the resulting set will be empty.
+As of 1.9, these methods _always_ return a new set, making them consistently usable with chaining and the `.end()` method. Prior to 1.9, they would return the old set only if there was a single target element. Note that these methods have always returned the aggregate set of all elements appended to the target elements. If no elements are selected by the target selector (e.g., `$( elements ).appendTo( "#not_found" )`) the resulting set will be empty.
 
 ### Ajax events should be attached to document
 
-As of jQuery 1.9, the global Ajax events (ajaxStart, ajaxStop, ajaxSend, ajaxComplete, ajaxError, and ajaxSuccess) are only triggered on the `document` element. Change the program to listen for the Ajax events on the document. For example, if the code currently looks like this:
-```javascript
-$("#status").ajaxStart(function(){ $(this).text("Ajax started"); });
+As of jQuery 1.9, the global Ajax events (`ajaxStart`, `ajaxStop`, `ajaxSend`, `ajaxComplete`, `ajaxError`, and `ajaxSuccess`) are only triggered on the `document` element. Change the program to listen for the Ajax events on the document. For example, if the code currently looks like this:
+```js
+$( "#status" ).on( "ajaxStart", function() {
+	$( this ).text( "Ajax started" );
+} );
 ```
 Change it to this:
-```javascript
-$(document).ajaxStart(function(){ $("#status").text("Ajax started"); });
+```js
+$( document ).on( "ajaxStart", function() {
+	$( "#status" ).text( "Ajax started" );
+} );
 ```
 
 ### Checkbox/radio state in a .trigger()ed "click" event
 
-When the _user_ clicks on a checkbox or radio button, the event handler sees the node in the state it will be in if `event.preventDefault()` is not called on the node--in essence, its new state. So for example, if the user clicks on an unchecked checkbox, the event handler will see a _checked_ box. Before 1.9, a synthetic event triggered by either `.trigger("click")` or `.click()` would see the checkbox in the opposite state than that of a user action. This has been fixed in 1.9 to reflect the same checked state as a user-initiated action.
+When the _user_ clicks on a checkbox or radio button, the event handler sees the node in the state it will be in if `event.preventDefault()` is not called on the node--in essence, its new state. So for example, if the user clicks on an unchecked checkbox, the event handler will see a _checked_ box. Before 1.9, a synthetic event triggered by either `.trigger( "click" )` or `.click()` would see the checkbox in the opposite state than that of a user action. This has been fixed in 1.9 to reflect the same checked state as a user-initiated action.
 
 ### Order of triggered "focus" events
 
-When the user clicks or tabs into a form element to bring it into focus, the browser first fires a blur event for the previously focused element and then a focus event for the new element. Prior to 1.9, a trigger()ed focus event using either `.trigger("focus")` or `.focus()` would fire a focus event for the new element and then the blur event for the previous element before finally actually focusing the element. In 1.9 this behavior has been changed to reflect the same order as if the user had caused the focus change.
+When the user clicks or tabs into a form element to bring it into focus, the browser first fires a blur event for the previously focused element and then a focus event for the new element. Prior to 1.9, a trigger()ed focus event using either `.trigger( "focus" )` or `.focus()` would fire a focus event for the new element and then the blur event for the previous element before finally actually focusing the element. In 1.9 this behavior has been changed to reflect the same order as if the user had caused the focus change.
 
-With native DOM focus events, the browser only calls a focus event handler if the target element is not already focused and can also successfully be focused. jQuery has always ensured that a call to `.trigger("focus")` or `.focus()` consistently runs any attached event handlers, even if the element cannot be focused, and jQuery 1.9 continues to do that. This is different behavior than the DOM `.focus()` method, which will not call event handlers in many cases including where the element is already focused or the element is disabled.
+With native DOM focus events, the browser only calls a focus event handler if the target element is not already focused and can also successfully be focused. jQuery has always ensured that a call to `.trigger( "focus" )` or `.focus()` consistently runs any attached event handlers, even if the element cannot be focused, and jQuery 1.9 continues to do that. This is different behavior than the DOM `.focus()` method, which will not call event handlers in many cases including where the element is already focused or the element is disabled.
 
-Unfortunately, all versions of Internet Explorer (6 through 10) fire focus events asynchronously. When you `.trigger("focus")` in IE, jQuery won't "see" the async focus event which will occur later, so it fires one of its own to ensure that a focus event always occurs as described above. This causes two calls to the event handler. To avoid this double-call--but risk that the event handler is not called at all--use the DOM focus method directly, e.g., `$("selector").get(0).focus()`.
+Unfortunately, all versions of Internet Explorer (6 through 10) fire focus events asynchronously. When you `.trigger( "focus" )` in IE, jQuery won't "see" the async focus event which will occur later, so it fires one of its own to ensure that a focus event always occurs as described above. This causes two calls to the event handler. To avoid this double-call--but risk that the event handler is not called at all--use the DOM focus method directly, e.g., `$( "selector" ).get( 0 ).focus()`.
 
-### jQuery(htmlString) versus jQuery(selectorString)
+### jQuery( htmlString ) versus jQuery( selectorString )
 
 Prior to 1.9, a string would be considered to be an HTML string if it had HTML tags anywhere within the string. This has the potential to cause inadvertent execution of code and reject valid selector strings. As of 1.9, a string is only considered to be HTML if it starts with a less-than ("`<`") character. The Migrate plugin can be used to restore the pre-1.9 behavior.
 
-If a string is known to be HTML but may start with arbitrary text that is not an HTML tag, pass it to `jQuery.parseHTML()` which will return an array of DOM nodes representing the  markup. A jQuery collection can be created from this, for example: `$($.parseHTML(htmlString))`. This would be considered best practice when processing HTML templates for example. Simple uses of literal strings such as `$("<p>Testing</p>").appendTo("body")` are unaffected by this change.
+If a string is known to be HTML but may start with arbitrary text that is not an HTML tag, pass it to `jQuery.parseHTML()` which will return an array of DOM nodes representing the  markup. A jQuery collection can be created from this, for example: `$( $.parseHTML( htmlString ) )`. This would be considered best practice when processing HTML templates for example. Simple uses of literal strings such as `$( "<p>Testing</p>" ).appendTo( "body" )` are unaffected by this change.
 
 Bottom line: HTML strings passed to `jQuery()` that start with something other than a less-than character will be interpreted as a selector. Since the string usually cannot be interpreted as a selector, the most likely result will be an "invalid selector syntax" error thrown by the Sizzle selector engine. Use `jQuery.parseHTML()` to parse arbitrary HTML.
 
@@ -98,7 +102,7 @@ When the jQuery Migrate plugin is used, it will use the old rules for determinin
 
 ### Events not fired by the .data() method; names with periods
 
-The `.data()` method had an undocumented and incredibly non-performant way to monitor setting and getting of values that was removed in 1.9. This has affected the interpretation of data names that contain periods, in a good way. As of 1.9, a call to `.data("abc.def")` retrieves the data for the name "abc.def" _only_, and never just "abc".  Note that the lower-level `jQuery.data()` method never supported events and so it has not changed. The jQuery Migrate plugin does _not_ restore the old behavior for this case.
+The `.data()` method had an undocumented and incredibly non-performant way to monitor setting and getting of values that was removed in 1.9. This has affected the interpretation of data names that contain periods, in a good way. As of 1.9, a call to `.data( "abc.def" )` retrieves the data for the name "abc.def" _only_, and never just "abc".  Note that the lower-level `jQuery.data()` method never supported events and so it has not changed. The jQuery Migrate plugin does _not_ restore the old behavior for this case.
 
 ### Ordering of disconnected nodes within a jQuery set
 
@@ -124,14 +128,14 @@ Here are some examples of correct usage when setting `checked` on a checkbox; th
 
 ```js
 // Correct if changing the attribute is desired
-$(elem).attr("checked", "checked");
+$( elem ).attr( "checked", "checked" );
 // Correct for checking the checkbox
-$(elem).prop("checked", true);
+$( elem ).prop( "checked", true );
 
 // Correct if removing the attribute is desired (rare)
-$(elem).removeAttr("checked");
+$( elem ).removeAttr( "checked" );
 // Correct for clearing the checkbox
-$(elem).prop("checked", false);
+$( elem ).prop( "checked", false );
 ```
 
 The `value` property versus attribute on `input` elements is another example of this ambiguity. The attribute generally reflects the value that was read from the HTML markup; the property reflects the current value. Since the `.val()` method is the recommended jQuery way to get or set the values of form elements, this confusion usually does not affect users.
@@ -140,7 +144,7 @@ However, when a selector like `"input[value=abc]"` is used, it should always sel
 
 The jQuery Migrate plugin restores the old attribute-vs-property rules.
 
-### $("input").attr("type", newValue) in oldIE
+### $( "input" ).attr( "type", newValue ) in oldIE
 
 Prior to version 1.9, jQuery would throw an exception in all browsers for any attempt to set the `type` attribute on an input or button element. This was done to accommodate the lowest common denominator; IE 6/7/8 throw an error if you attempt to change the type of an input element. As of jQuery 1.9, we allow you to set the type of an element if the browser allows it. However, your own code will need to be aware that attempting to do this on oldIE will still throw an error. The jQuery Migrate plugin warns when you attempt to set the `type` attribute but does not throw a JavaScript error.
 
@@ -154,7 +158,7 @@ The remaining purpose of the deprecated `.selector` property on a jQuery object 
 
 ### jQuery.attr()
 
-In 1.9 we have removed the undocumented signature jQuery.attr(elem, name, value, pass) using the pass argument. Any code that depended on this should be rewritten, but the jQuery Migrate plugin can provide backward-compatible behavior and will warn if this signature is used.
+In 1.9 we have removed the undocumented signature `jQuery.attr( elem, name, value, pass )` using the pass argument. Any code that depended on this should be rewritten, but the jQuery Migrate plugin can provide backward-compatible behavior and will warn if this signature is used.
 
 ### jQuery.ajax returning a JSON result of an empty string
 
@@ -162,11 +166,11 @@ Prior to 1.9, an ajax call that expected a return data type of JSON or JSONP wou
 
 ### jQuery.proxy() context
 
-New in 1.9, the function returned by calling jQuery.proxy with a falsy context will preserve its `this` object for the provided function. Previously, a falsy value for context would get translated into the global object (window) if null/undefined, or else wrapped in an object (e.g., new Boolean(false)).
+New in 1.9, the function returned by calling jQuery.proxy with a falsy context will preserve its `this` object for the provided function. Previously, a falsy value for context would get translated into the global object (window) if null/undefined, or else wrapped in an object (e.g., `new Boolean( false )`).
 
-### .data("events")
+### .data( "events" )
 
-Prior to 1.9, `.data("events")` could be used to retrieve jQuery's undocumented internal event data structure for an element if no other code had defined a data element with the name "events". This special case has been removed in 1.9. There is no public interface to retrieve this internal data structure, and it remains undocumented. However, the jQuery Migrate plugin restores this behavior for code that depends upon it.
+Prior to 1.9, `.data( "events" )` could be used to retrieve jQuery's undocumented internal event data structure for an element if no other code had defined a data element with the name "events". This special case has been removed in 1.9. There is no public interface to retrieve this internal data structure, and it remains undocumented. However, the jQuery Migrate plugin restores this behavior for code that depends upon it.
 
 ### Removed properties of the Event object
 

--- a/pages/upgrade-guide/3.0.md
+++ b/pages/upgrade-guide/3.0.md
@@ -128,10 +128,10 @@ https://bugs.jquery.com/ticket/13335
 The document-ready processing in jQuery has been powered by the `jQuery.Deferred` implementation since jQuery 1.6. As part of jQuery 3.0's alignment with the Promises/A+ standard, document-ready handlers are called asynchronously even if the document is currently ready at the point where the handler is added. This provides a consistent code execution order that is independent of whether the document is ready or not. For example, consider this code:
 
 ```js
-$(function(){
-   console.log("ready");
-});
-console.log("outside ready");
+$( function() {
+   console.log( "ready" );
+} );
+console.log( "outside ready" );
 ```
 
 In jQuery 3.0 this will always log "outside ready" followed by "ready" regardless of whether the document is ready at the point of execution. Earlier versions may log the messages in either order.
@@ -186,12 +186,12 @@ https://github.com/jquery/jquery/issues/2319
 jQuery 3.0 supports the `for...of` loop introduced in ES2015. It allows looping over iterable objects including `Array`, `Map`, and `Set`. When using this loop, the value obtained is a DOM element of the jQuery collection, one at a time. Note that you will need to be using an environment that supports ES2015 or a transpiler such as Babel to use `for...of`.  Here is an example:
 
 ```js
-var elems = $(".someclass");
+var elems = $( ".someclass" );
 
 // Classic jQuery way
-$.each(function(i, elem) {
+$.each( function( i, elem ) {
   // work with elem (or "this" object)
-});
+} );
 
 // Prettier ES2015 way
 for ( let elem of elems ) {
@@ -206,11 +206,11 @@ https://github.com/jquery/jquery/issues/1693
 `jQuery.ready` has been consumable as a promise-like object ("thenable" in Promise terms) since jQuery version 1.8. As of jQuery 3.0 this object is documented as supported via `jQuery.when` or the native `Promise.resolve()`. No code should make assumptions about whether this object is a jQuery `Deferred` or some other type of promise object such as a native Promise. Typical usage might look like this:
 
 ```js
-$.when( $.ready, $.getScript("optional.js") ).then(function() {
+$.when( $.ready, $.getScript( "optional.js" ) ).then( function() {
    // the document is ready and optional.js has loaded/run
-}).catch( function() {
+} ).catch( function() {
    // an error occurred
-});
+} );
 ```
 
 https://github.com/jquery/api.jquery.com/pull/530
@@ -226,17 +226,17 @@ Since all the browsers supported by jQuery 3.0 support the native `JSON.parse()`
 
 https://github.com/jquery/jquery/issues/2800
 
-#### Deprecated: document-ready handlers other than `jQuery(function)`
+#### Deprecated: document-ready handlers other than `jQuery( function )`
 
 Due to historical compatibility issues there are a multitude of ways to set a document ready handler. All of the following are equivalent and call the function `fn` when the document is ready:
 
 ```js
-$(fn);
-$().ready(fn);
-$(document).ready(fn);
-$("selector").ready(fn);
+$( fn );
+$().ready( fn );
+$( document ).ready( fn );
+$( "selector" ).ready( fn );
 ```
-As of jQuery 3.0 the recommended way to add a ready  handler is the first method, `$(fn)`. As noted in the Event section, the `$(document).on("ready", fn)` event form has slightly different semantics and was removed in jQuery 3.0.
+As of jQuery 3.0 the recommended way to add a ready  handler is the first method, `$(fn)`. As noted in the Event section, the `$( document ).on( "ready", fn )` event form has slightly different semantics and was removed in jQuery 3.0.
 
 ### Data
 
@@ -244,24 +244,24 @@ As of jQuery 3.0 the recommended way to add a ready  handler is the first method
 
 As of jQuery 3.0, all data names are stored in jQuery's internal data object in camelCase (e.g., `clickCount`), rather than kebab-case (e.g. `click-count`). This is consistent with the way that standard DOM turns dashed names into camel case for JavaScript names in CSS and data properties.
 
-In general, kebab case still works in jQuery 3.0 when setting or getting a specific data item, e.g. `.data("right-aligned")`, but if you retrieve the internal data object it will now have the data item in camel case (`rightAligned`). The main difference in 3.0 is when you use kebab case names directly on the data object instead of using the `.data()` API to get or set them.
+In general, kebab case still works in jQuery 3.0 when setting or getting a specific data item, e.g. `.data( "right-aligned" )`, but if you retrieve the internal data object it will now have the data item in camel case (`rightAligned`). The main difference in 3.0 is when you use kebab case names directly on the data object instead of using the `.data()` API to get or set them.
 
 For example:
 ```js
-var $div = $("<div />");
-$div.data("clickCount", 2);
-$div.data("clickCount"); // 2
-$div.data("click-count", 3);
-$div.data("clickCount"); // 3
-$div.data("click-count"); // 3
+var $div = $( "<div />" );
+$div.data( "clickCount", 2 );
+$div.data( "clickCount" ); // 2
+$div.data( "click-count", 3 );
+$div.data( "clickCount" ); // 3
+$div.data( "click-count" ); // 3
 
 var allData = $div.data();
 allData.clickCount; // 3
-allData["click-count"]; // undefined
-allData["click-count"] = 14;
-$div.data("click-count"); // 3, NOT 14 as it would be in jQuery 2.x
+allData[ "click-count" ]; // undefined
+allData[ "click-count" ] = 14;
+$div.data( "click-count" ); // 3, NOT 14 as it would be in jQuery 2.x
 allData.clickCount; // 3
-allData["click-count"]; // 14
+allData[ "click-count" ]; // 14
 ```
 
 https://github.com/jquery/jquery/issues/2070  
@@ -292,30 +292,30 @@ In jQuery 1.x and 2.x, an uncaught exception inside a callback function halts co
 For example, consider this code using the new standard Promises/A+ behavior:
 
 ```js
-$.ajax("/status")
-   .then(function(data) {
+$.ajax( "/status" )
+   .then( function( data ) {
       whoops();
       // console shows "jQuery.Deferred exception: whoops is not a function"
       // no further code executes in this function
-   })
-   .catch(function(arg) {
+   } )
+   .catch( function( arg ) {
       // this code executes after the error above
       // arg is an Error object, "whoops is not a function"
-   });
+   } );
 ```
 
 Compare that to the old-style Deferred methods:
 
 ```js
-$.ajax("/status")
-   .done(function(data) {
+$.ajax( "/status" )
+   .done( function( data ) {
       whoops();
       // console shows: "whoops is not a function"
       // no further code executes in this function
-   })
-   .fail(function(arg) {
+   } )
+   .fail( function( arg ) {
       // this code does not execute since the exception was not caught
-   });
+   } );
 ```
 
 Note that jQuery logs a message to the console when it is inside a Deferred and a JavaScript exception occurs. These messages take the form `jQuery.Deferred exception: (error message)`. If you do not want any console output on these exceptions, set `jQuery.Deferred.exceptionHook` to `undefined`. If you need further help in finding errors reported this way, use the [jquery-deferred-reporter plugin](https://github.com/dmethvin/jquery-deferred-reporter) during development to obtain stack traces.
@@ -328,7 +328,7 @@ The Promises/A+ spec says that promises are always resolved with a <em>single va
 
 ```js
 // Typical old uses of .then() that are not Promises/A+ compatible
-$.ajax("url").then(
+$.ajax( "url" ).then(
     // success
     function( data, textStatus, jqXHR ) { /* code */ },
     // error
@@ -336,11 +336,11 @@ $.ajax("url").then(
 );
 
 // Rewrite to this in order to maintain previous behavior
-$.ajax("url")
+$.ajax( "url" )
     // success
-    .done(function( data, textStatus, jqXHR ) { /* code */ })
+    .done( function( data, textStatus, jqXHR ) { /* code */ } )
     // error
-    .fail(function( jqXHR, textStatus, errorThrown ) { /* code */ });
+    .fail( function( jqXHR, textStatus, errorThrown ) { /* code */ } );
 ```
 
 Another behavior change required for Promises/A+ compliance is that Deferred `.then()` callbacks are *always* called asynchronously. Previously, if a `.then()` callback was added to a Deferred that was already resolved or rejected, the callback would run immediately and synchronously.
@@ -370,7 +370,7 @@ https://github.com/jquery/jquery/issues/2710
 
 
 ### Dimensions
-#### Breaking change: .width(), .height(), .css("width"), and .css("height") can return non-integer values
+#### Breaking change: .width(), .height(), .css( "width" ), and .css( "height" ) can return non-integer values
 
 Before version 3.0, jQuery used the DOM `offsetWidth` and `offsetHeight` properties to determine the dimensions of an element, and these properties always return integers. With jQuery 3.0 we get more precise values via the DOM `getBoundingClientRect` API, and these may not be integers. If your code always expects integers for dimensions, it may need to be adjusted to deal with this extra precision.
 
@@ -410,14 +410,14 @@ The easing functions called by `.animate()` are passed single argument, the perc
 
 Example of an old easing method:
 ```js
-$.easing.easeInOutSine =  function (x, t, b, c, d) {
-  return -c/2 * (Math.cos(Math.PI*t/d) - 1) + b;
+$.easing.easeInOutSine = function( x, t, b, c, d ) {
+  return -c / 2 * ( Math.cos( Math.PI * t / d ) - 1 ) + b;
 };
 ```
 The same easing method rewritten:
 ```js
-$.easing.easeInOutSine =  function (x) {
-  return -0.5*(Math.cos(Math.PI*x) - 1);
+$.easing.easeInOutSine = function( x ) {
+  return -0.5 * ( Math.cos( Math.PI * x ) - 1 );
 };
 ```
 
@@ -428,11 +428,11 @@ https://github.com/jquery/api.jquery.com/issues/912
 
 #### Breaking change: .load(), .unload(), and .error() removed
 
-These methods are shortcuts for event operations, but had several API limitations. The event `.load()` method conflicted with the ajax `.load()` method. The `.error()` method could not be used with `window.onerror` because of the way the DOM method is defined. If you need to attach events by these names, use the `.on()` method, e.g. change `$("img").load(fn)` to `$("img").on("load", fn)`.
+These methods are shortcuts for event operations, but had several API limitations. The event `.load()` method conflicted with the ajax `.load()` method. The `.error()` method could not be used with `window.onerror` because of the way the DOM method is defined. If you need to attach events by these names, use the `.on()` method, e.g. change `$( "img" ).load( fn )` to `$( "img" ).on( "load", fn )`.
 
 https://github.com/jquery/jquery/issues/2286
 
-#### Breaking change: `.on("ready", fn)` removed
+#### Breaking change: `.on( "ready", fn )` removed
 
 jQuery no longer supports a synthetic event named `"ready"` that can be used with the event functions. This event was error-prone and deprecated in jQuery 1.8 because it would only call the callback if it was attached before the document was ready. Replace any uses with `$(fn)` instead, which works reliably.
 
@@ -464,9 +464,9 @@ Five years ago in jQuery 1.7 we introduced the `.on()` method for attaching even
 
 
 ### Manipulation
-#### Breaking change:  `.wrapAll(function)` only calls the function once
+#### Breaking change:  `.wrapAll( function )` only calls the function once
 
-In previous versions, the `.wrapAll()` method acted like `.wrap()` when a function was passed. This has been corrected; now and `.wrapAll(function)` calls its function once, using the string result of the function call  to wrap the entire collection.
+In previous versions, the `.wrapAll()` method acted like `.wrap()` when a function was passed. This has been corrected; now and `.wrapAll( function )` calls its function once, using the string result of the function call  to wrap the entire collection.
 
 https://github.com/jquery/jquery/issues/1843
 
@@ -490,9 +490,9 @@ An element is considered now visible if it has a layout box returned from the DO
 https://github.com/jquery/jquery/issues/2227  
 https://github.com/jquery/jquery/issues/2604  
 
-#### Breaking change: `jQuery("#")` and `.find("#")` are invalid syntax
+#### Breaking change: `jQuery( "#" )` and `.find( "#" )` are invalid syntax
 
-jQuery 3.0 throws a syntax error if a selector string consists of nothing but a hash-mark. In previous versions, `$("#")` returned an empty collection and `.find("#")` threw an error.
+jQuery 3.0 throws a syntax error if a selector string consists of nothing but a hash-mark. In previous versions, `$("#")` returned an empty collection and `.find( "#" )` threw an error.
 
 https://github.com/jquery/jquery/pull/1682
 


### PR DESCRIPTION
Also, adjust code formatting in upgrade guides to match the jQuery code style.