### PR TITLE
Download: Simplified download page, supports dual version downloads

### DIFF
--- a/pages/download.md
+++ b/pages/download.md
@@ -10,17 +10,48 @@ To locally download these files, right-click the link and select "Save as..." fr
 
 Download the compressed, production version:
 
-<a class="button db" href="https://code.jquery.com/jquery-4.0.0.min.js">Download jQuery 4.0.0</a>
+<ul style="display: grid;grid-template-columns: repeat(auto-fit,minmax(260px,1fr));gap: 16px;">
+<li>
 
-* [Download the uncompressed development version of jQuery 4.0.0](https://code.jquery.com/jquery-4.0.0.js)
-* [Download the map file for jQuery 4.0.0](https://code.jquery.com/jquery-4.0.0.min.map)
-* [jQuery 4.0.0 blog post with release notes](https://blog.jquery.com/2026/01/17/jquery-4-0-0/)
+### 4.0.0(Maintenance)
+* [Changelog](https://blog.jquery.com/2026/01/17/jquery-4-0-0/) / [Upgrade](https://jquery.com/upgrade-guide/4.0/)
+
+#### Full build
+
+* [Minified](https://code.jquery.com/jquery-4.0.0.min.js)
+* [Uncompressed development](https://code.jquery.com/jquery-4.0.0.js)
+* [Map file](https://code.jquery.com/jquery-4.0.0.min.map)
+
+#### Slim build
 
 The slim build is a smaller version, that excludes the [ajax](https://api.jquery.com/category/ajax/) and [effects](https://api.jquery.com/category/effects/) modules:
 
-* [Download jQuery 4.0.0 slim build](https://code.jquery.com/jquery-4.0.0.slim.min.js)
-* [Download the uncompressed development version of the jQuery 4.0.0 slim build](https://code.jquery.com/jquery-4.0.0.slim.js)
-* [Download the map for the jQuery 4.0.0 slim build](https://code.jquery.com/jquery-4.0.0.slim.min.map)
+* [Minified](https://code.jquery.com/jquery-4.0.0.slim.min.js)
+* [Uncompressed development](https://code.jquery.com/jquery-4.0.0.slim.js)
+* [Map file](https://code.jquery.com/jquery-4.0.0.slim.min.map)
+
+</li>
+<li>
+
+### 3.7.1(Limited maintenance)
+* [Changelog](https://blog.jquery.com/2023/08/28/jquery-3-7-1-released-reliable-table-row-dimensions/) / [Upgrade](https://jquery.com/upgrade-guide/3.5/)
+
+#### Full build
+
+* [Minified](https://code.jquery.com/jquery-3.7.1.min.js)
+* [Uncompressed development](https://code.jquery.com/jquery-3.7.1.js)
+* [Map file](https://code.jquery.com/jquery-3.7.1.min.map)
+
+#### Slim build
+
+The slim build is a smaller version, that excludes the [ajax](https://api.jquery.com/category/ajax/) and [effects](https://api.jquery.com/category/effects/) modules:
+
+* [Minified](https://code.jquery.com/jquery-3.7.1.slim.min.js)
+* [Uncompressed development](https://code.jquery.com/jquery-3.7.1.slim.js)
+* [Map file](https://code.jquery.com/jquery-3.7.1.slim.min.map)
+
+</li>
+</ul>
 
 The uncompressed version is best used during development or debugging; the compressed file saves bandwidth and improves performance in production. You can download the [source map](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) file to help with debugging the compressed production version. The source map is _not_ required for end-users to run jQuery; it is a tool to help improve a developer's debugging experience. As of jQuery 1.11/2.1, we [no longer link source maps](https://blog.jquery.com/2014/01/24/jquery-1-11-and-2-1-released/) to compressed releases by default.
 


### PR DESCRIPTION
@mgol @timmywil 
The jQuery team released version 4.0 at the beginning of the year, but support for version 3.0 is not yet fully exhausted, and version 3.8.0 is expected to be released sometime later this year. Therefore, I was concerned that the download page might offer two different major versions simultaneously when version 3.8.0 is released. So, I optimized the layout of the download page to better provide downloads of both versions for a period of time.

Since version 3.x will soon be officially discontinued, I used a small amount of CSS in Markdown so that it can be easily removed when support ends.

I also referenced https://github.com/jquery/jquery/pull/5787, which uses Maintenance and Limited maintenance to differentiate versions.
new:
<img width="1237" height="770" alt="new" src="https://github.com/user-attachments/assets/dfd035c2-4746-445c-8a4b-ab64cd66070f" />


old:
<img width="1229" height="794" alt="old" src="https://github.com/user-attachments/assets/25e0a542-ff85-4d3c-b545-febf73237550" />
